### PR TITLE
fix: 修复非法的 Ant Design Modal 属性, 把 destroyOnHidden 改成 destroyOnClose

### DIFF
--- a/apps/web/src/modules/intelligent-analysis/UserJourney/OverviewDashboard/CapabilityBenchmarkModal.tsx
+++ b/apps/web/src/modules/intelligent-analysis/UserJourney/OverviewDashboard/CapabilityBenchmarkModal.tsx
@@ -178,7 +178,7 @@ const CapabilityBenchmarkModal: React.FC<CapabilityBenchmarkModalProps> = ({
       onCancel={onClose}
       footer={null}
       width={1080}
-      destroyOnHidden
+      destroyOnClose
     >
       {!repo || !benchmark ? null : (
         <div className="benchmark-modal-body">

--- a/apps/web/src/modules/intelligent-analysis/UserJourney/OverviewDashboard/IssueDetailModal.tsx
+++ b/apps/web/src/modules/intelligent-analysis/UserJourney/OverviewDashboard/IssueDetailModal.tsx
@@ -528,7 +528,7 @@ const IssueDetailModal: React.FC<IssueDetailModalProps> = ({
           </button>
         </div>
       }
-      destroyOnHidden
+      destroyOnClose
     >
       <div className="max-h-[70vh] overflow-y-auto rounded-xl border border-slate-200">
         <table className="w-full table-fixed border-collapse text-center text-[12px] text-slate-700 md:text-[13px]">

--- a/apps/web/src/modules/intelligent-analysis/UserJourney/OverviewDashboard/PainEditModal.tsx
+++ b/apps/web/src/modules/intelligent-analysis/UserJourney/OverviewDashboard/PainEditModal.tsx
@@ -53,7 +53,7 @@ const PainEditModal: React.FC<PainEditModalProps> = ({
       }}
       title="编辑痛点"
       width={720}
-      destroyOnHidden
+      destroyOnClose
     >
       <div className="grid grid-cols-2 gap-3">
         <Input

--- a/apps/web/src/modules/intelligent-analysis/UserJourney/OverviewDashboard/RepoProgressSection.tsx
+++ b/apps/web/src/modules/intelligent-analysis/UserJourney/OverviewDashboard/RepoProgressSection.tsx
@@ -2373,7 +2373,7 @@ const RepoProgressSection: React.FC<RepoProgressSectionProps> = ({
         open={rerunModal.open}
         title={rerunTargetRepo ? `${rerunTargetRepo.name} · 重跑` : '仓库重跑'}
         onCancel={closeRerunModal}
-        destroyOnHidden
+        destroyOnClose
         width={960}
         footer={
           operatorUser
@@ -2525,7 +2525,7 @@ const RepoProgressSection: React.FC<RepoProgressSectionProps> = ({
             : '重跑记录'
         }
         onCancel={closeRerunRecordsModal}
-        destroyOnHidden
+        destroyOnClose
         footer={[
           <Button key="close" onClick={closeRerunRecordsModal}>
             关闭

--- a/apps/web/src/modules/intelligent-analysis/UserJourney/OverviewDashboard/ScoreTrendModal.tsx
+++ b/apps/web/src/modules/intelligent-analysis/UserJourney/OverviewDashboard/ScoreTrendModal.tsx
@@ -33,7 +33,7 @@ const ScoreTrendModal: React.FC<ScoreTrendModalProps> = ({
       footer={null}
       onCancel={onClose}
       width={860}
-      destroyOnHidden
+      destroyOnClose
     >
       <div className="mb-3">
         <Title level={5} style={{ margin: 0 }}>

--- a/apps/web/src/modules/intelligent-analysis/UserJourney/components/KeyActionsSection.tsx
+++ b/apps/web/src/modules/intelligent-analysis/UserJourney/components/KeyActionsSection.tsx
@@ -179,7 +179,7 @@ const LogOutputModal: React.FC<{
       width={'80vw'}
       footer={null}
       styles={{ body: { padding: 0 } }}
-      destroyOnHidden
+      destroyOnClose
     >
       <div className="max-h-[70vh] overflow-y-auto">
         {loading ? (

--- a/apps/web/src/modules/intelligent-analysis/UserJourney/components/PainLevelConfirmModal/components.tsx
+++ b/apps/web/src/modules/intelligent-analysis/UserJourney/components/PainLevelConfirmModal/components.tsx
@@ -1223,7 +1223,7 @@ export const RollbackConfirmModal: React.FC<{
         ? `回退到${STATUS_LABELS[rollbackTarget] || rollbackTarget}`
         : '回退'
     }
-    destroyOnHidden
+    destroyOnClose
   >
     <div className="space-y-3">
       <div>

--- a/apps/web/src/modules/intelligent-analysis/UserJourney/components/PainLevelConfirmModal/index.tsx
+++ b/apps/web/src/modules/intelligent-analysis/UserJourney/components/PainLevelConfirmModal/index.tsx
@@ -439,7 +439,7 @@ const PainLevelConfirmModal: React.FC<Props> = ({
           paddingRight: '8px',
         },
       }}
-      destroyOnHidden
+      destroyOnClose
       footer={
         useCustomFooter ? (
           <ModalFooter

--- a/apps/web/src/modules/os-selection/DataView/index.tsx
+++ b/apps/web/src/modules/os-selection/DataView/index.tsx
@@ -25,7 +25,7 @@ const DataView = () => {
     {
       key: '2',
       label: t('os-selection:tabs.my_reports'),
-      destroyOnHidden: true,
+      destroyOnClose: true,
       children: activeKey === '2' ? <MyReports /> : '', // 我的报告
     },
   ];


### PR DESCRIPTION
Ant Design v5.9.2 (as shown in package.json) uses destroyOnClose, NOT destroyOnHidden. The destroyOnHidden property doesn't exist in Ant Design v5, which means:

Modal content is not destroyed when closed Form state persists between opens Potential memory leaks from uncleaned components Data confusion when reopening modals with different data

fix: change `destroyOnHidden` to `destroyOnClose`