### PR TITLE
fix: bodyStyle 已被废弃，改为 styles

### DIFF
--- a/apps/web/src/modules/intelligent-analysis/DataView/Overview/Project/index.tsx
+++ b/apps/web/src/modules/intelligent-analysis/DataView/Overview/Project/index.tsx
@@ -154,10 +154,12 @@ const Main: React.FC<MainProps> = ({ projectType = 'flutter' }) => {
         style={{ top: 20 }}
         footer={null}
         destroyOnClose
-        bodyStyle={{
-          padding: 0,
-          maxHeight: 'calc(100vh - 120px)',
-          overflow: 'auto',
+        styles={{
+          body: {
+            padding: 0,
+            maxHeight: 'calc(100vh - 120px)',
+            overflow: 'auto',
+          },
         }}
       >
         <DetailPage

--- a/apps/web/src/modules/intelligent-analysis/GovernancePlatform/Overview/Project/index.tsx
+++ b/apps/web/src/modules/intelligent-analysis/GovernancePlatform/Overview/Project/index.tsx
@@ -123,10 +123,12 @@ const Main: React.FC<MainProps> = ({ projectType = 'flutter' }) => {
         style={{ top: 20 }}
         footer={null}
         destroyOnClose
-        bodyStyle={{
-          padding: 0,
-          maxHeight: 'calc(100vh - 120px)',
-          overflow: 'auto',
+        styles={{
+          body: {
+            padding: 0,
+            maxHeight: 'calc(100vh - 120px)',
+            overflow: 'auto',
+          },
         }}
       >
         <DetailPage

--- a/apps/web/src/modules/intelligent-analysis/GovernancePlatformNew/Project/index.tsx
+++ b/apps/web/src/modules/intelligent-analysis/GovernancePlatformNew/Project/index.tsx
@@ -900,10 +900,12 @@ const GovernanceTabPanel: React.FC<{
         style={{ top: 20 }}
         footer={null}
         destroyOnClose
-        bodyStyle={{
-          maxHeight: 'calc(100vh - 140px)',
-          overflow: 'auto',
-          padding: 24,
+        styles={{
+          body: {
+            maxHeight: 'calc(100vh - 140px)',
+            overflow: 'auto',
+            padding: 24,
+          },
         }}
       >
         {tableModal?.type === 'organization' ? (
@@ -944,10 +946,12 @@ const GovernanceTabPanel: React.FC<{
         style={{ top: 20 }}
         footer={null}
         destroyOnClose
-        bodyStyle={{
-          padding: 0,
-          maxHeight: 'calc(100vh - 120px)',
-          overflow: 'auto',
+        styles={{
+          body: {
+            padding: 0,
+            maxHeight: 'calc(100vh - 120px)',
+            overflow: 'auto',
+          },
         }}
       >
         {selectedDetailUser ? (

--- a/apps/web/src/modules/intelligent-analysis/UserJourney/components/ComparePanoramaCard.tsx
+++ b/apps/web/src/modules/intelligent-analysis/UserJourney/components/ComparePanoramaCard.tsx
@@ -676,7 +676,7 @@ const ComparePanoramaCard: React.FC<ComparePanoramaCardProps> = ({
     <Card
       bordered={false}
       className="rounded-3xl border border-white/80 bg-white/90 shadow-[0_24px_70px_rgba(15,23,42,0.08)]"
-      bodyStyle={{ padding: 24 }}
+      styles={{ body: { padding: 24 } }}
     >
       <div className="flex flex-col gap-6">
         <div>

--- a/apps/web/src/modules/intelligent-analysis/UserJourney/components/CompareStepSection.tsx
+++ b/apps/web/src/modules/intelligent-analysis/UserJourney/components/CompareStepSection.tsx
@@ -31,7 +31,7 @@ const EmptyStepCard: React.FC<{ projectName: string }> = ({ projectName }) => {
     <Card
       bordered={false}
       className="h-full w-full rounded-3xl border border-white/80 bg-white/90 shadow-[0_24px_70px_rgba(15,23,42,0.08)]"
-      bodyStyle={{ padding: 24 }}
+      styles={{ body: { padding: 24 } }}
     >
       <div className="text-xl font-semibold text-slate-900">开发旅程</div>
       <div className="mt-6 rounded-[28px] border border-dashed border-slate-200 bg-slate-50/80 px-6 py-12 text-center text-sm text-slate-500">

--- a/apps/web/src/modules/intelligent-analysis/UserJourney/components/ComparisonTableCard.tsx
+++ b/apps/web/src/modules/intelligent-analysis/UserJourney/components/ComparisonTableCard.tsx
@@ -48,7 +48,7 @@ const ComparisonTableCard: React.FC<ComparisonTableCardProps> = ({
     <Card
       bordered={false}
       className="h-full rounded-3xl border border-white/80 bg-white/90 shadow-[0_24px_70px_rgba(15,23,42,0.08)]"
-      bodyStyle={{ padding: 24, height: '100%' }}
+      styles={{ body: { padding: 24, height: '100%' } }}
     >
       <div className="flex h-full flex-col">
         <div className="mb-4 flex min-h-[28px] items-center text-base font-semibold text-slate-800">

--- a/apps/web/src/modules/intelligent-analysis/UserJourney/components/ReportSummaryCard.tsx
+++ b/apps/web/src/modules/intelligent-analysis/UserJourney/components/ReportSummaryCard.tsx
@@ -95,7 +95,7 @@ const ReportSummaryCard: React.FC<ReportSummaryCardProps> = ({
     <Card
       bordered={false}
       className="rounded-3xl border border-white/80 bg-white/90 shadow-[0_24px_70px_rgba(15,23,42,0.08)]"
-      bodyStyle={{ padding: 24 }}
+      styles={{ body: { padding: 24 } }}
     >
       <div className=">lg:flex-row >lg:items-stretch flex flex-col gap-5">
         {/* ── 左侧：指标概览（50%）── */}

--- a/apps/web/src/modules/intelligent-analysis/UserJourney/components/StepDetailCard.tsx
+++ b/apps/web/src/modules/intelligent-analysis/UserJourney/components/StepDetailCard.tsx
@@ -61,7 +61,7 @@ const StepDetailCard: React.FC<StepDetailCardProps> = ({
       style={
         hideTitle ? { boxShadow: 'none', background: 'transparent' } : undefined
       }
-      bodyStyle={{ padding: hideTitle ? 0 : 24 }}
+      styles={{ body: { padding: hideTitle ? 0 : 24 } }}
     >
       {!hideTitle && (
         <div className="mb-5">

--- a/apps/web/src/modules/intelligent-analysis/UserJourney/components/StepSidebar.tsx
+++ b/apps/web/src/modules/intelligent-analysis/UserJourney/components/StepSidebar.tsx
@@ -19,7 +19,7 @@ const StepSidebar: React.FC<StepSidebarProps> = ({
     <Card
       bordered={false}
       className="w-full rounded-3xl border border-white/80 bg-white/90 shadow-[0_20px_48px_rgba(15,23,42,0.08)]"
-      bodyStyle={{ padding: 16 }}
+      styles={{ body: { padding: 16 } }}
     >
       <Title level={4} style={{ marginTop: 0, marginBottom: 16 }}>
         步骤名称

--- a/apps/web/src/modules/oh/DataView/HatchingTreatment/components/ApprovalGuide.tsx
+++ b/apps/web/src/modules/oh/DataView/HatchingTreatment/components/ApprovalGuide.tsx
@@ -125,7 +125,7 @@ const ApprovalGuide: React.FC<ApprovalGuideProps> = ({
         ]}
         width={1000}
         destroyOnClose
-        bodyStyle={{ maxHeight: '70vh', overflowY: 'auto', padding: '24px' }}
+        styles={{ body: { maxHeight: '70vh', overflowY: 'auto', padding: '24px' } }}
       >
         {/* 说明文字 */}
         <div className="mb-6 rounded-lg bg-blue-50 p-4">


### PR DESCRIPTION
Ant Design v5 中 Card 组件的 bodyStyle 已被废弃，正确用法是 styles={{ body: {...} }}