### PR TITLE
feat: add Charter section to About page

### DIFF
--- a/apps/web/src/modules/about/05Charter.tsx
+++ b/apps/web/src/modules/about/05Charter.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import LinkLegacy from '@common/components/LinkLegacy';
+import { Paragraph, DocTitle } from './components';
+
+const Charter = () => {
+  return (
+    <div className="mb-24">
+      <DocTitle>Charter / 章程</DocTitle>
+      <Paragraph>
+        The OSS Compass community charter is available
+        <LinkLegacy href="https://github.com/oss-compass/community-zh/tree/main/governance">
+          here
+        </LinkLegacy>
+        . / OSS Compass 社区章程请
+        <LinkLegacy href="https://github.com/oss-compass/community-zh/tree/main/governance">
+          点击查看
+        </LinkLegacy>
+        。
+      </Paragraph>
+    </div>
+  );
+};
+
+export default Charter;

--- a/apps/web/src/modules/about/index.tsx
+++ b/apps/web/src/modules/about/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Banner from './Banner';
 import Introduce from './Introduce';
+import Charter from './05Charter';
 import Board from './10Board';
 import Members from './20Members';
 import TechnicalCommittee from './30TechnicalCommittee';
@@ -17,6 +18,7 @@ const About = () => {
       <div className="py-20">
         <div className="mx-auto  w-[1000px] md:w-full md:px-4">
           <Introduce />
+          <Charter />
           <Board />
           <Members />
           <TechnicalCommittee />


### PR DESCRIPTION
## Summary
Fixes #193

Add a Charter section to the About page, displayed before the Board members section as requested in the issue. Links to the OSS Compass community charter at https://github.com/oss-compass/community-zh/tree/main/governance.

### Changes
- Created `05Charter.tsx` component with bilingual text (English + Chinese) since the charter is currently only available in Chinese
- Added `Charter` component to `index.tsx`, rendered between `Introduce` and `Board`

### Screenshot
The Charter section appears between the Introduction and Board Members sections on the About page.

## Test plan
- [x] Component follows existing patterns (DocTitle, Paragraph, LinkLegacy)
- [x] Bilingual text included as charter is Chinese-only
- [x] No breaking changes to existing components