### PR TITLE
fix: show analyzing status instead of 0 during analysis

### DIFF
--- a/apps/web/src/modules/intelligent-analysis/GovernancePlatformNew/Project/index.tsx
+++ b/apps/web/src/modules/intelligent-analysis/GovernancePlatformNew/Project/index.tsx
@@ -23,6 +23,7 @@ import {
   TabsProps,
   Tag,
 } from 'antd';
+import Analyzing from '@modules/oh/components/Analyzing';
 import PanoramaChart from '../../GovernancePlatform/Overview/Project/PanoramaChart';
 import DeveloperRegionChart from '../../GovernancePlatform/Overview/Project/DeveloperRegionChart';
 import RepoTable from '../../GovernancePlatform/Overview/Project/RepoTable';
@@ -683,7 +684,7 @@ const GovernanceTabPanel: React.FC<{
     null
   );
   const [showDetailModal, setShowDetailModal] = useState(false);
-  const { data: organizationRegions } = useQuery({
+  const { data: organizationRegions, isError: orgRegionsError } = useQuery({
     queryKey: ['intelligent-analysis', 'organizations', 'regions', dataset],
     queryFn: async () => {
       const params = new URLSearchParams();
@@ -705,7 +706,7 @@ const GovernanceTabPanel: React.FC<{
     },
     staleTime: 1000 * 60 * 5,
   });
-  const { data: developerRegions } = useQuery({
+  const { data: developerRegions, isError: devRegionsError } = useQuery({
     queryKey: ['intelligent-analysis', 'developers', 'regions', dataset],
     queryFn: async () => {
       const params = new URLSearchParams();
@@ -791,6 +792,10 @@ const GovernanceTabPanel: React.FC<{
   const handleTableRegionChange = (regions: string[]) => {
     setTableModal((current) => (current ? { ...current, regions } : current));
   };
+
+  if (orgRegionsError && devRegionsError) {
+    return <Analyzing />;
+  }
 
   return (
     <>


### PR DESCRIPTION
## Summary

Fixes #285

When a project's analysis is still in progress, the depth insight page (深度洞察) shows "0" for all metrics. This happens because the data API returns 500 when the JSON data file doesn't exist yet, and the client silently falls back to empty arrays.

## Changes

- Add `isError` check to both region queries in `GovernanceTabPanel`
- When both queries fail (data unavailable = analysis in progress), render the existing `Analyzing` component instead of the dashboard with zero values

## Test plan

- [ ] Open a project page where analysis is in progress
- [ ] Verify "报告分析中" is displayed instead of "0" values
- [ ] Open a project page with available data — verify the dashboard renders normally