### PR TITLE
fix: includeCommonIssues 在 6 处 API 调用中硬编码为 true 的问题

### DIFF
--- a/apps/web/src/modules/intelligent-analysis/UserJourney/OverviewDashboard/RepoProgressSection.tsx
+++ b/apps/web/src/modules/intelligent-analysis/UserJourney/OverviewDashboard/RepoProgressSection.tsx
@@ -2791,7 +2791,10 @@ const RepoProgressSection: React.FC<RepoProgressSectionProps> = ({
       const search = new URLSearchParams();
       if (org) search.set('org', org);
       search.set('tab', currentTab);
-      search.set('include_common_issues', 'true');
+      search.set(
+        'include_common_issues',
+        commonOnly === false ? 'false' : 'true'
+      );
       if (commonOnly !== undefined && commonOnly !== null) {
         search.set('common_only', String(commonOnly));
       }

--- a/apps/web/src/modules/intelligent-analysis/UserJourney/OverviewDashboard/index.tsx
+++ b/apps/web/src/modules/intelligent-analysis/UserJourney/OverviewDashboard/index.tsx
@@ -111,7 +111,7 @@ const OverviewDashboard: React.FC<OverviewDashboardProps> = ({ org }) => {
         viewType: 'repo',
         org,
         tab: currentTab,
-        includeCommonIssues: true,
+        includeCommonIssues,
         commonOnly:
           issueSourceMode === 'common'
             ? true
@@ -144,7 +144,7 @@ const OverviewDashboard: React.FC<OverviewDashboardProps> = ({ org }) => {
         viewType: 'repo',
         org,
         tab: 'overall',
-        includeCommonIssues: true,
+        includeCommonIssues,
         commonOnly:
           issueSourceMode === 'common'
             ? true
@@ -177,7 +177,7 @@ const OverviewDashboard: React.FC<OverviewDashboardProps> = ({ org }) => {
     queryFn: () =>
       fetchOverviewSummary({
         org,
-        includeCommonIssues: true,
+        includeCommonIssues,
         commonOnly:
           issueSourceMode === 'common'
             ? true
@@ -201,7 +201,7 @@ const OverviewDashboard: React.FC<OverviewDashboardProps> = ({ org }) => {
       queryFn: () =>
         fetchOverviewCloseRateTrends({
           org,
-          includeCommonIssues: true,
+          includeCommonIssues,
           commonOnly:
             issueSourceMode === 'common'
               ? true


### PR DESCRIPTION
<img width="1874" height="947" alt="Selection_20260713_01" src="https://github.com/user-attachments/assets/fcd52b8c-901d-4bc0-8a19-563bb7e7cb41" />
<img width="1705" height="260" alt="Selection_20260713_02" src="https://github.com/user-attachments/assets/3f64125d-dc48-4bcd-82ac-3abf56a66c12" />

问题：includeCommonIssues 在 6 处 API 调用中硬编码为 true，导致 UI 取消勾选"包含共性问题"后 API 仍然返回共性问题。同时 RepoProgressSection 已经有 commonOnly prop，CSV 导出那里也需要跟着修复。