### PR TITLE
fix: preserve zero CI scores in overview

### DIFF
--- a/apps/web/src/modules/intelligent-analysis/DeveloperExperience/CiExperience/components/CiOverview/communityMetrics.test.ts
+++ b/apps/web/src/modules/intelligent-analysis/DeveloperExperience/CiExperience/components/CiOverview/communityMetrics.test.ts
@@ -1,0 +1,35 @@
+import { CI_DATA } from '../../data';
+import { CI_JOURNEY } from '../CiReport/journeyData';
+import { computeCommunityOverview } from './communityMetrics';
+
+describe('computeCommunityOverview', () => {
+  it('keeps a latest score of zero instead of falling back to an older score', () => {
+    const latestCostScores = (['runtime', 'opsnn'] as const).map((repo) => {
+      const journey = CI_JOURNEY[repo];
+      const latestDay = journey.days[journey.days.length - 1];
+      return journey.boards[latestDay].scores!.dims.cost;
+    });
+    const originalScores = latestCostScores.map(({ score }) => score);
+
+    try {
+      latestCostScores.forEach((dimension) => {
+        dimension.score = 0;
+      });
+
+      const overview = computeCommunityOverview(CI_DATA);
+      const costKpi = overview.kpis.find(({ label }) => label === '成本');
+
+      expect(costKpi).toMatchObject({
+        value: '0',
+        bad: true,
+        trend: {
+          last: 0,
+        },
+      });
+    } finally {
+      latestCostScores.forEach((dimension, index) => {
+        dimension.score = originalScores[index];
+      });
+    }
+  });
+});

--- a/apps/web/src/modules/intelligent-analysis/DeveloperExperience/CiExperience/components/CiOverview/communityMetrics.ts
+++ b/apps/web/src/modules/intelligent-analysis/DeveloperExperience/CiExperience/components/CiOverview/communityMetrics.ts
@@ -440,7 +440,11 @@ export const computeCommunityOverview = (
   // 得分权威口径取自 CI_JOURNEY[repo].boards[day].scores（与 CI 报告页概览同源）。
   const scoreDayLatest = (
     sel: (s: CiJourneyScores) => number | null
-  ): { latest: number | null; series: (number | null)[] } => {
+  ): {
+    latest: number | null;
+    lastVal: number | null;
+    series: (number | null)[];
+  } => {
     const series = agg.days.map((dt) => {
       const perDay: number[] = [];
       repos.forEach((x) => {
@@ -454,9 +458,10 @@ export const computeCommunityOverview = (
         ? +(perDay.reduce((a, b) => a + b, 0) / perDay.length).toFixed(1)
         : null;
     });
-    const lastVal = lastNZ(series);
+    const lastVal =
+      [...series].reverse().find((value) => value != null) ?? null;
     const latest = lastVal != null ? Math.round(lastVal) : null;
-    return { latest, series };
+    return { latest, lastVal, series };
   };
 
   const scoreDefs: Array<{
@@ -504,9 +509,8 @@ export const computeCommunityOverview = (
   ];
 
   const kpis: CiKpi[] = scoreDefs.map((def) => {
-    const { latest, series } = scoreDayLatest(def.sel);
+    const { latest, lastVal, series } = scoreDayLatest(def.sel);
     const first = firstNZ(series);
-    const lastVal = lastNZ(series);
     const d = delta(first, lastVal, false);
     return {
       label: def.label,


### PR DESCRIPTION
## Problem

When the latest community CI dimension score is `0`, the overview shows an older non-zero score as the current KPI value. The trend metadata also reports that older value as the latest point.

Scores use `number | null`, where `0` is a valid score and `null` represents missing data. Treating both as absent makes the community overview disagree with the repository summaries and the source CI report.

## Root cause

`scoreDayLatest` used the shared `lastNZ` helper. That helper intentionally skips zero values for metrics where zero means no observation, but it is not suitable for CI scores. The KPI mapping then called `lastNZ` a second time for the trend metadata.

## Solution

- Select the latest non-null score, preserving a valid value of zero.
- Reuse that same observed value for the KPI and its trend metadata.
- Add a regression test that sets both repositories' latest cost score to zero and verifies the displayed KPI and trend value.

## How to reproduce

1. Set the latest cost-dimension score for both CI repositories to `0`.
2. Run `computeCommunityOverview(CI_DATA)`.
3. Before this change, the cost KPI falls back to `67` and its trend reports `66.5`; after this change, both use the latest score of `0`.

## Tests performed

- `yarn test:ci` — 18 suites, 60 tests passed
- `yarn workspace @oss-compass/web tsc --noEmit --pretty false`
- `yarn workspace @oss-compass/web lint`
- `yarn build`
- Prettier check for both changed files

## Screenshots

Not applicable; this is a calculation fix with no layout change.

## Related issue

None.
