### PR TITLE
fix: path traversal in intelligent-analysis dataset APIs

### DIFF
--- a/apps/web/src/modules/intelligent-analysis/server/intelligentAnalysisNewDatasetCache.ts
+++ b/apps/web/src/modules/intelligent-analysis/server/intelligentAnalysisNewDatasetCache.ts
@@ -2,6 +2,7 @@ import fs from 'fs/promises';
 import path from 'path';
 
 import { classifyOrganization } from '@modules/intelligent-analysis/GovernancePlatform/Overview/Project/utils/orgClassifier';
+import { isSafePathSegment } from '@modules/intelligent-analysis/server/pathSafety';
 
 type RawRow = Record<string, any>;
 
@@ -290,6 +291,10 @@ export async function getDatasetCacheValue(
   dataset: string,
   mode: 'backup' | 'detail'
 ): Promise<DatasetCacheValue> {
+  if (!isSafePathSegment(dataset)) {
+    throw new Error(`Invalid dataset: ${dataset}`);
+  }
+
   const cacheKey = `${dataset}__${mode}`;
   const cached = datasetCache.get(cacheKey);
   if (cached) return cached;

--- a/apps/web/src/modules/intelligent-analysis/server/pathSafety.test.ts
+++ b/apps/web/src/modules/intelligent-analysis/server/pathSafety.test.ts
@@ -1,0 +1,44 @@
+import { isSafePathSegment, resolveFileInsideDir } from './pathSafety';
+
+describe('isSafePathSegment', () => {
+  it('accepts ordinary dataset / user identifiers', () => {
+    expect(isSafePathSegment('CANN')).toBe(true);
+    expect(isSafePathSegment('github:alice')).toBe(true);
+    expect(isSafePathSegment('张 三')).toBe(true);
+    expect(isSafePathSegment('model.v2')).toBe(true);
+  });
+
+  it('rejects empty / non-string values', () => {
+    expect(isSafePathSegment('')).toBe(false);
+    expect(isSafePathSegment(undefined)).toBe(false);
+    expect(isSafePathSegment(null)).toBe(false);
+    expect(isSafePathSegment(123)).toBe(false);
+  });
+
+  it('rejects path separators and traversal segments', () => {
+    expect(isSafePathSegment('..')).toBe(false);
+    expect(isSafePathSegment('../../etc')).toBe(false);
+    expect(isSafePathSegment('a/b')).toBe(false);
+    expect(isSafePathSegment('a\\b')).toBe(false);
+    expect(isSafePathSegment('..\\..\\secret')).toBe(false);
+  });
+});
+
+describe('resolveFileInsideDir', () => {
+  const dir = '/srv/compass/public/test/intelligent-analysis-new/CANN';
+
+  it('resolves ordinary file names inside the dir', () => {
+    expect(resolveFileInsideDir(dir, 'alice_main.json')).toBe(
+      dir + '/alice_main.json'
+    );
+    expect(resolveFileInsideDir(dir + '/', 'alice.json')).toBe(
+      dir + '/alice.json'
+    );
+  });
+
+  it('returns null when the resolved path escapes the dir', () => {
+    expect(resolveFileInsideDir(dir, '../../secret.json')).toBeNull();
+    expect(resolveFileInsideDir(dir, '/etc/passwd.json')).toBeNull();
+    expect(resolveFileInsideDir(dir, '..')).toBeNull();
+  });
+});

--- a/apps/web/src/modules/intelligent-analysis/server/pathSafety.ts
+++ b/apps/web/src/modules/intelligent-analysis/server/pathSafety.ts
@@ -1,0 +1,23 @@
+import path from 'path';
+
+// dataset/userId 等外部输入最终会拼进文件系统路径，
+// 带路径分隔符时可以逃出数据集目录（如 userId=../../secret 读取任意 json 文件）
+export function isSafePathSegment(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    value.length > 0 &&
+    value !== '..' &&
+    !value.includes('/') &&
+    !value.includes('\\')
+  );
+}
+
+// 在 dir 内解析文件路径，逃出 dir 时返回 null
+export function resolveFileInsideDir(
+  dir: string,
+  fileName: string
+): string | null {
+  const resolved = path.resolve(dir, fileName);
+  const dirWithSep = dir.endsWith(path.sep) ? dir : dir + path.sep;
+  return resolved.startsWith(dirWithSep) ? resolved : null;
+}

--- a/apps/web/src/pages/api/intelligent-analysis/projects/[dataset]/developers.ts
+++ b/apps/web/src/pages/api/intelligent-analysis/projects/[dataset]/developers.ts
@@ -4,6 +4,7 @@ import {
   getDatasetCacheValue,
   type DeveloperRow,
 } from '@modules/intelligent-analysis/server/intelligentAnalysisNewDatasetCache';
+import { isSafePathSegment } from '@modules/intelligent-analysis/server/pathSafety';
 
 function parseCsvList(value: unknown): string[] {
   if (!value) return [];
@@ -129,6 +130,11 @@ export default async function handler(
   const dataset = String(req.query.dataset || '');
   if (!dataset) {
     res.status(400).json({ message: 'Missing dataset' });
+    return;
+  }
+
+  if (!isSafePathSegment(dataset)) {
+    res.status(400).json({ message: 'Invalid dataset' });
     return;
   }
 

--- a/apps/web/src/pages/api/intelligent-analysis/projects/[dataset]/organizations.ts
+++ b/apps/web/src/pages/api/intelligent-analysis/projects/[dataset]/organizations.ts
@@ -3,6 +3,7 @@ import {
   getDatasetCacheValue,
   type OrganizationRow,
 } from '@modules/intelligent-analysis/server/intelligentAnalysisNewDatasetCache';
+import { isSafePathSegment } from '@modules/intelligent-analysis/server/pathSafety';
 
 function parseCsvList(value: unknown): string[] {
   if (!value) return [];
@@ -100,6 +101,11 @@ export default async function handler(
   const dataset = String(req.query.dataset || '');
   if (!dataset) {
     res.status(400).json({ message: 'Missing dataset' });
+    return;
+  }
+
+  if (!isSafePathSegment(dataset)) {
+    res.status(400).json({ message: 'Invalid dataset' });
     return;
   }
 

--- a/apps/web/src/pages/api/intelligent-analysis/projects/[dataset]/participant-details.ts
+++ b/apps/web/src/pages/api/intelligent-analysis/projects/[dataset]/participant-details.ts
@@ -3,6 +3,11 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import fs from 'fs/promises';
 import path from 'path';
 
+import {
+  isSafePathSegment,
+  resolveFileInsideDir,
+} from '@modules/intelligent-analysis/server/pathSafety';
+
 type ParticipantTableRow = {
   key: string;
   具体人员: string;
@@ -210,8 +215,9 @@ async function loadEntry(dataset: string, organizationId: string) {
   const fileBase = normalizeUserFileBase(organizationId);
   const cacheKey = `${dataset}__${fileBase}`;
   const datasetDir = await resolveDatasetDir(dataset);
-  const filePath = path.resolve(datasetDir, `${fileBase}.json`);
-  if (!(await fileExists(filePath))) return { entry: null, filePath };
+  const filePath = resolveFileInsideDir(datasetDir, `${fileBase}.json`);
+  if (!filePath || !(await fileExists(filePath)))
+    return { entry: null, filePath: null };
 
   const stat = await fs.stat(filePath);
   const shouldCache = stat.size > CACHE_THRESHOLD_BYTES;
@@ -272,6 +278,11 @@ export default async function handler(
   const organizationId = String(req.query.organizationId || '');
   if (!organizationId) {
     res.status(400).json({ message: 'Missing organizationId' });
+    return;
+  }
+
+  if (!isSafePathSegment(dataset) || !isSafePathSegment(organizationId)) {
+    res.status(400).json({ message: 'Invalid dataset or organizationId' });
     return;
   }
 

--- a/apps/web/src/pages/api/intelligent-analysis/projects/[dataset]/regions.ts
+++ b/apps/web/src/pages/api/intelligent-analysis/projects/[dataset]/regions.ts
@@ -4,6 +4,7 @@ import {
   getDatasetCacheValue,
   type RegionMetric,
 } from '@modules/intelligent-analysis/server/intelligentAnalysisNewDatasetCache';
+import { isSafePathSegment } from '@modules/intelligent-analysis/server/pathSafety';
 
 const allowedMetrics: RegionMetric[] = [
   'all',
@@ -25,6 +26,11 @@ export default async function handler(
   const dataset = String(req.query.dataset || '');
   if (!dataset) {
     res.status(400).json({ message: 'Missing dataset' });
+    return;
+  }
+
+  if (!isSafePathSegment(dataset)) {
+    res.status(400).json({ message: 'Invalid dataset' });
     return;
   }
 

--- a/apps/web/src/pages/api/intelligent-analysis/projects/[dataset]/user-detail.ts
+++ b/apps/web/src/pages/api/intelligent-analysis/projects/[dataset]/user-detail.ts
@@ -3,6 +3,11 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import fs from 'fs/promises';
 import path from 'path';
 
+import {
+  isSafePathSegment,
+  resolveFileInsideDir,
+} from '@modules/intelligent-analysis/server/pathSafety';
+
 const backupCache = new Map<string, unknown[]>();
 
 async function fileExists(filePath: string): Promise<boolean> {
@@ -115,14 +120,24 @@ export default async function handler(
     return;
   }
 
+  if (!isSafePathSegment(dataset) || !isSafePathSegment(userId)) {
+    res.status(400).json({ message: 'Invalid dataset or userId' });
+    return;
+  }
+
   const datasetDir = await resolveDatasetDir(dataset);
   const fileBase = normalizeUserFileBase(userId);
-  const mainFilePath = path.resolve(datasetDir, `${fileBase}_main.json`);
-  const fallbackFilePath = path.resolve(datasetDir, `${fileBase}.json`);
+  const mainFilePath = resolveFileInsideDir(
+    datasetDir,
+    `${fileBase}_main.json`
+  );
+  const fallbackFilePath = resolveFileInsideDir(datasetDir, `${fileBase}.json`);
 
-  const filePath = (await fileExists(mainFilePath))
-    ? mainFilePath
-    : (await fileExists(fallbackFilePath)) ? fallbackFilePath : null;
+  const filePath =
+    (mainFilePath && (await fileExists(mainFilePath)) ? mainFilePath : null) ??
+    (fallbackFilePath && (await fileExists(fallbackFilePath))
+      ? fallbackFilePath
+      : null);
 
   if (!filePath) {
     try {


### PR DESCRIPTION
## Problem

The intelligent-analysis API routes build file-system paths from request-controlled values without validation:

- `GET /api/intelligent-analysis/projects/[dataset]/user-detail?userId=...`
- `GET /api/intelligent-analysis/projects/[dataset]/participant-details?organizationId=...`

`normalizeUserFileBase()` only replaces `:` and spaces, so a `userId` containing `..` / `/` escapes the dataset directory in `path.resolve(datasetDir, \`\${fileBase}_main.json\`)` and the endpoint returns the content of **any \*.json file on the server** (with `Cache-Control: public`). The `dataset` route parameter reaches the same code paths (directory resolution in every route, plus `${dataset}_backup.json` / `${dataset}_detail.json` in `getDatasetCacheValue`).

## Fix

- Add `modules/intelligent-analysis/server/pathSafety.ts` with `isSafePathSegment()` (rejects empty values, path separators and `..`) and `resolveFileInsideDir()` (containment check as defense in depth).
- Validate `dataset` (+ `userId` / `organizationId`) in all five `[dataset]` routes (`user-detail`, `participant-details`, `developers`, `organizations`, `regions`) → `400 Invalid ...` on violation.
- Containment check where the final read path is built (`user-detail.ts`, `participant-details.ts`, `getDatasetCacheValue`).

## Verification

- New unit tests `pathSafety.test.ts` cover ordinary ids (`CANN`, `github:alice`, `张 三`) being accepted and traversal payloads (`../x`, `a/b`, `a\\b`, `..`) being rejected, plus the containment check.
- `yarn test:ci`: 17 suites / 56 tests pass. `yarn build` succeeds.

中文说明：`user-detail` / `participant-details` 等接口把 `dataset`、`userId`、`organizationId` 未经校验直接拼进文件路径，传 `userId=../../xxx` 即可逃出数据集目录读取服务器上任意 json 文件。本 PR 统一增加了路径段校验和目录包含检查，并补充单元测试。

## Runtime verification (before / after, `next dev` + curl)

A decoy file `public/test/secret_check.json` (one level **above** the dataset directory) was placed on the server, then the same requests were replayed against unfixed `main` and this branch:

| Request (dataset `CANN`) | unfixed `main` | this branch |
| --- | --- | --- |
| `user-detail?userId=../../secret_check` | **200 + secret file content (leak)** | 400 Invalid dataset or userId |
| `user-detail?userId=../A2A/github_JadenHuang2023` | **200 + another dataset's user record (cross-dataset leak)** | 400 |
| `user-detail?userId=..%2F..%2Fsecret_check` (encoded) | leak | 400 |
| `user-detail?userId=..%5C..%5Csecret_check` (backslash) | — | 400 |
| `dataset=..%2F..%2Ftest` (encoded slash in route param) | — | 400 |
| `user-detail?userId=gitcode:2203_75544541` (valid) | 200 | 200, identical data |
| `participant-details?organizationId=github:JadenHuang2023` (valid) | — | 200 |
| `developers` / `organizations` / `regions` (valid) | — | 200, full datasets |

No functional regression on any of the five routes.