### PR TITLE
fix: open redirect on lab model invite confirm page

### DIFF
--- a/apps/web/src/common/utils/url.test.ts
+++ b/apps/web/src/common/utils/url.test.ts
@@ -10,6 +10,7 @@ import {
   removeExtname,
   removeTrailingSlash,
   getNameSpacePng,
+  getSameOriginHref,
 } from './url';
 
 describe('utils url ', () => {
@@ -221,6 +222,43 @@ describe('utils url ', () => {
 
     testCases.map((item) => {
       expect(getNameSpacePng(item.input)).toEqual(item.result);
+    });
+  });
+
+  describe('getSameOriginHref', () => {
+    const origin = 'https://oss-compass.org';
+
+    it('allows same-site relative and absolute URLs', () => {
+      expect(getSameOriginHref('/lab/model/detail?model=1', origin)).toEqual(
+        'https://oss-compass.org/lab/model/detail?model=1'
+      );
+      expect(
+        getSameOriginHref('https://oss-compass.org/lab/model/detail', origin)
+      ).toEqual('https://oss-compass.org/lab/model/detail');
+    });
+
+    it('blocks external sites and pseudo-protocol URLs', () => {
+      expect(getSameOriginHref('https://evil.com/phish', origin)).toEqual('');
+      expect(getSameOriginHref('//evil.com/phish', origin)).toEqual('');
+      expect(getSameOriginHref('javascript:alert(1)', origin)).toEqual('');
+      expect(getSameOriginHref('data:text/html,<script>', origin)).toEqual('');
+      // 仿冒域名与异端口都不是同源
+      expect(
+        getSameOriginHref('https://oss-compass.org.evil.com/x', origin)
+      ).toEqual('');
+      expect(
+        getSameOriginHref('https://oss-compass.org:8080/x', origin)
+      ).toEqual('');
+    });
+
+    it('blocks cross-scheme navigation (http -> https site)', () => {
+      expect(getSameOriginHref('http://oss-compass.org/lab/x', origin)).toEqual(
+        ''
+      );
+    });
+
+    it('returns empty for empty input', () => {
+      expect(getSameOriginHref('', origin)).toEqual('');
     });
   });
 });

--- a/apps/web/src/common/utils/url.ts
+++ b/apps/web/src/common/utils/url.ts
@@ -9,6 +9,21 @@ export const parseUrl = (url: string): URL | null => {
   }
 };
 
+// 校验外部传入的重定向地址是否指向本站（相对路径或同源绝对 URL），
+// 外站 / 伪协议（javascript: 等）一律返回空串，防止开放重定向
+export const getSameOriginHref = (raw: string, origin?: string): string => {
+  if (!raw) return '';
+  const base =
+    origin ?? (typeof window !== 'undefined' ? window.location.origin : '');
+  if (!base) return '';
+  try {
+    const url = new URL(raw, base);
+    return url.origin === base ? url.href : '';
+  } catch {
+    return '';
+  }
+};
+
 //https://github.com/cli/cli =>  cli/cli
 export const getPathname = (url: string): string => {
   const u = parseUrl(url);

--- a/apps/web/src/pages/lab/model/invite/confirm/index.tsx
+++ b/apps/web/src/pages/lab/model/invite/confirm/index.tsx
@@ -11,6 +11,7 @@ import { GetServerSidePropsContext } from 'next';
 import { useTranslation, Trans } from 'next-i18next';
 import { toast } from 'react-hot-toast';
 import CheckTerms from '@modules/lab/model/components/CheckTerms';
+import { getSameOriginHref } from '@common/utils';
 
 export async function getServerSideProps(context: GetServerSidePropsContext) {
   const { req } = context;
@@ -68,10 +69,13 @@ const Content = () => {
         <Button
           size="lg"
           onClick={() => {
-            if (select) {
-              window.location.href = acceptUrl;
-            } else {
+            if (!select) {
               toast.error(t('lab:please_check_the_terms'));
+              return;
+            }
+            const target = getSameOriginHref(acceptUrl);
+            if (target) {
+              window.location.href = target;
             }
           }}
         >


### PR DESCRIPTION
## Problem

On `/lab/model/invite/confirm`, the “agree to join” button navigates to `accept_url` taken verbatim from the URL query:

```ts
window.location.href = acceptUrl; // router.query.accept_url
```

Anyone can craft `/lab/model/invite/confirm?accept_url=https://evil.com/...&invitee=...&model=...` and send it to a member; after they check the terms and click the button they are redirected to an arbitrary external site (a `javascript:` URL is equally accepted). This is a classic open-redirect / phishing vector on an authenticated page.

## Fix

Only navigate when the target resolves to the current site's origin (`new URL(raw, window.location.origin)`), which accepts both relative paths and absolute same-origin URLs as the backend normally sends, and drops external / malformed / pseudo-protocol values.

## Verification

- Manual matrix: `/lab/model/x` ✅, `https://<same-origin>/...` ✅, `https://evil.com` ❌, `//evil.com` ❌, `javascript:...` ❌, garbage ❌.
- `yarn test:ci` and `yarn build` pass.

中文说明：邀请确认页把 URL 参数 `accept_url` 原样作为跳转目标，构造恶意链接可把已登录成员重定向到任意外站（钓鱼）。修复后仅允许跳转本站地址。

## Update (testability & evidence)

The same-origin check now lives in `common/utils/url.ts` as `getSameOriginHref()` (shared util, origin injectable for tests), and the page imports it — behavior unchanged. Covered by unit tests in `common/utils/url.test.ts`:

- allows same-site relative paths and absolute URLs
- blocks external sites, `//host`, `javascript:`, `data:`, look-alike domains (`oss-compass.org.evil.com`), different ports, and http→https cross-scheme navigation
- empty input → no navigation

**Test results:** `yarn test:ci` 16 suites / 55 tests pass on this branch; `tsc --noEmit` 0 errors; prettier clean; production build verified on the combined tree of all fix branches.