### PR TITLE
fix: Updated Since chart draws the median line with mean values

### DIFF
--- a/apps/web/src/modules/analyze/DataView/CommunityActivity/UpdatedSince.test.tsx
+++ b/apps/web/src/modules/analyze/DataView/CommunityActivity/UpdatedSince.test.tsx
@@ -1,0 +1,54 @@
+import { convertResult } from './utils';
+import { DataContainerResult } from '@modules/analyze/type';
+
+const buildResult = (
+  partial: Partial<DataContainerResult>
+): DataContainerResult => ({
+  isCompare: false,
+  compareLabels: [],
+  xAxis: ['2024-01-01'],
+  yResults: [],
+  summaryMean: [],
+  summaryMedian: [],
+  ...partial,
+});
+
+describe('UpdatedSince convertResult', () => {
+  it('converts mean and median independently from months to days', () => {
+    const result = convertResult(
+      buildResult({ summaryMean: [2], summaryMedian: [3] })
+    );
+
+    expect(result.summaryMean).toEqual([60]);
+    // 回归点：median 必须由 summaryMedian 换算（3×30），
+    // 而不是错误地借用已换算过的 summaryMean（2×30×30=1800）
+    expect(result.summaryMedian).toEqual([90]);
+  });
+
+  it('converts each y series value', () => {
+    const result = convertResult(
+      buildResult({
+        yResults: [
+          {
+            label: 'a',
+            level: 'community',
+            legendName: 'a',
+            key: 'a',
+            data: [1, 2],
+          },
+        ] as any,
+      })
+    );
+
+    expect(result.yResults[0].data).toEqual([30, 60]);
+  });
+
+  it('leaves non-numeric summary values untouched', () => {
+    const result = convertResult(
+      buildResult({ summaryMean: ['-'], summaryMedian: [null as any] })
+    );
+
+    expect(result.summaryMean).toEqual(['-']);
+    expect(result.summaryMedian).toEqual([null]);
+  });
+});

--- a/apps/web/src/modules/analyze/DataView/CommunityActivity/UpdatedSince.tsx
+++ b/apps/web/src/modules/analyze/DataView/CommunityActivity/UpdatedSince.tsx
@@ -10,23 +10,8 @@ import { useTranslation } from 'next-i18next';
 import { TransOpt } from '@modules/analyze/type';
 import CardDropDownMenu from '@modules/analyze/components/CardDropDownMenu';
 import { getYAxisWithUnit } from '@common/options';
-import { convertMonthsToDays } from '@common/utils/format';
+import { convertResult } from './utils';
 import { DataContainerResult } from '@modules/analyze/type';
-
-// convert months to days.
-const convertResult = (result: DataContainerResult) => {
-  result.summaryMean = result.summaryMean.map((value) =>
-    convertMonthsToDays(value)
-  );
-  result.summaryMedian = result.summaryMean.map((value) =>
-    convertMonthsToDays(value)
-  );
-  result.yResults = result.yResults.map((item) => {
-    item.data = item.data.map((value) => convertMonthsToDays(value));
-    return item;
-  });
-  return result;
-};
 
 const UpdatedSince = () => {
   const { t, i18n } = useTranslation();

--- a/apps/web/src/modules/analyze/DataView/CommunityActivity/utils.ts
+++ b/apps/web/src/modules/analyze/DataView/CommunityActivity/utils.ts
@@ -1,0 +1,17 @@
+import { convertMonthsToDays } from '@common/utils/format';
+import { DataContainerResult } from '@modules/analyze/type';
+
+// convert months to days.
+export const convertResult = (result: DataContainerResult) => {
+  result.summaryMean = result.summaryMean.map((value) =>
+    convertMonthsToDays(value)
+  );
+  result.summaryMedian = result.summaryMedian.map((value) =>
+    convertMonthsToDays(value)
+  );
+  result.yResults = result.yResults.map((item) => {
+    item.data = item.data.map((value) => convertMonthsToDays(value));
+    return item;
+  });
+  return result;
+};


### PR DESCRIPTION
## Problem

In `modules/analyze/DataView/CommunityActivity/UpdatedSince.tsx`, `convertResult()` builds the median series from the **mean** series:

```ts
result.summaryMean = result.summaryMean.map((value) => convertMonthsToDays(value));
result.summaryMedian = result.summaryMean.map((value) => convertMonthsToDays(value)); // ← wrong source
```

Two effects:

1. The “median” reference line shows the **mean** data.
2. Since `summaryMean` was already converted to days one line above, the values are converted again (`convertMonthsToDays` multiplies by 30), so the median line is mean × 900 relative to the metric.

Visible whenever the median option is enabled on the Updated Since card (Robustness → Activity).

## Fix

`result.summaryMedian = result.summaryMedian.map(...)` — convert the actual median series.

## Verification

- `yarn test:ci`, `yarn build` pass; chart data flow unchanged otherwise.

中文说明：Updated Since 图表构造 median 曲线时误用了 `summaryMean`（复制粘贴错误），导致中位数线显示的是均值数据、且被重复换算（×30 两次）。

## Update (testability & evidence)

`convertResult()` moved to `CommunityActivity/utils.ts` (imported by the card, behavior unchanged) and is now covered by `UpdatedSince.test.tsx`:

- mean and median convert independently: `summaryMedian [3] → [90]` — the old code produced `[1800]` (borrowing the already-converted mean), so this test **fails on `main`**
- y-series values convert, non-numeric values (`'-'`, null) pass through untouched

**Test results:** `yarn test:ci` 17 suites / 54 tests pass; `tsc --noEmit` 0 errors; prettier clean.