### PR TITLE
fix: repo filter never rendered on the Issue / PR tabs of metric detail

### DIFF
--- a/apps/web/src/modules/analyze/components/MetricDetail/DetailHeaderFilter.test.tsx
+++ b/apps/web/src/modules/analyze/components/MetricDetail/DetailHeaderFilter.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import DetailHeaderFilter from './DetailHeaderFilter';
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('./CommunityFilter', () => ({
+  __esModule: true,
+  default: () => <div data-testid="community-filter" />,
+}));
+
+describe('DetailHeaderFilter', () => {
+  it('renders the community repo filter on the issue tab at community level', () => {
+    // 回归点：曾经错误比较 level === 'community1'（不存在的枚举值），
+    // 导致社区级报告的 issue / pr 页签永远不显示仓库筛选器
+    render(
+      <DetailHeaderFilter
+        type="issue"
+        level="community"
+        label="octocat/hello"
+      />
+    );
+
+    expect(screen.getByTestId('community-filter')).toBeInTheDocument();
+  });
+
+  it('renders the community repo filter on the pr tab at community level', () => {
+    render(
+      <DetailHeaderFilter type="pr" level="community" label="octocat/hello" />
+    );
+
+    expect(screen.getByTestId('community-filter')).toBeInTheDocument();
+  });
+
+  it('does not render the repo filter at project / repo level', () => {
+    render(
+      <DetailHeaderFilter type="issue" level="project" label="octocat/hello" />
+    );
+
+    expect(screen.queryByTestId('community-filter')).toBeNull();
+  });
+
+  it('renders the bot select on the contributor tab with the repo filter at community level', () => {
+    render(
+      <DetailHeaderFilter
+        type="contributor"
+        level="community"
+        label="octocat/hello"
+        isBot={false}
+      />
+    );
+
+    expect(screen.getByTestId('community-filter')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/modules/analyze/components/MetricDetail/DetailHeaderFilter.tsx
+++ b/apps/web/src/modules/analyze/components/MetricDetail/DetailHeaderFilter.tsx
@@ -26,7 +26,7 @@ const DetailHeaderFilter: React.FC<{
   if (type == 'issue') {
     return (
       <>
-        {level === 'community1' ? (
+        {level === 'community' ? (
           <CommunityFilter
             label={label}
             onRepoChange={(v) => onRepoChange(v)}
@@ -41,7 +41,7 @@ const DetailHeaderFilter: React.FC<{
   } else if (type == 'pr') {
     return (
       <>
-        {level === 'community1' ? (
+        {level === 'community' ? (
           <CommunityFilter
             label={label}
             onRepoChange={(v) => onRepoChange(v)}


### PR DESCRIPTION
## Problem

`modules/analyze/components/MetricDetail/DetailHeaderFilter.tsx` compares the level against `'community1'` for the `issue` and `pr` tabs:

```tsx
{level === 'community1' ? <CommunityFilter ... /> : <div>Issues</div>}
```

`community1` does not exist — the `Level` enum is `'community' | 'project' | 'repo'` (`modules/analyze/constant.ts`), and the contributor tab in the same file correctly checks `level === 'community'`. The condition is always false, so on a **community-level** analysis the repository filter silently disappears on the Issue and PR tabs (introduced by #351). Filtering issues/PRs by repo is impossible, while the contributor tab still has it.

## Fix

`'community1'` → `'community'` in both branches.

## Verification

- `yarn test:ci`, `yarn build` pass.

中文说明：`DetailHeaderFilter` 中 Issue / PR 页签用 `level === 'community1'`（枚举中不存在的值）判断社区级，导致社区报告的 Issue / PR 页签永远不显示按仓库筛选器，与 contributor 页签行为不一致。该笔误由 #351 引入。

## Update (testability & evidence)

Added `DetailHeaderFilter.test.tsx` (CommunityFilter mocked):

- issue tab at community level → repo filter rendered (**fails on `main`**, where the filter never appeared)
- pr tab at community level → repo filter rendered
- project level → no repo filter
- contributor tab at community level → repo filter + bot select (existing behavior preserved)

**Test results:** `yarn test:ci` 17 suites / 55 tests pass; `tsc --noEmit` 0 errors; prettier clean.