### PR TITLE
fix: crash on metric detail page when no verified item exists

### DIFF
--- a/apps/web/src/modules/analyze/DataView/MetricDetail/index.test.tsx
+++ b/apps/web/src/modules/analyze/DataView/MetricDetail/index.test.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import MetricDetail from './index';
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    query: { slugs: 'abc123' },
+    asPath: '/analyze/insight/abc123',
+  }),
+}));
+
+jest.mock('@modules/analyze/hooks/useVerifyDetailRangeQuery', () => ({
+  __esModule: true,
+  default: () => ({ isLoading: false, data: undefined }),
+}));
+
+jest.mock('@modules/analyze/hooks/useHandleQueryParams', () => ({
+  useHandleQueryParams: () => ({ handleQueryParams: jest.fn() }),
+}));
+
+jest.mock('@modules/analyze/components/NavBar/MerticDatePicker', () => ({
+  __esModule: true,
+  default: () => <div />,
+}));
+
+jest.mock('@modules/analyze/components/NavBar/LabelItems', () => ({
+  __esModule: true,
+  default: () => <div />,
+}));
+
+jest.mock('@common/components/Tab', () => ({
+  __esModule: true,
+  default: ({ value }: { value: string }) => (
+    <div data-testid="my-tab">{value}</div>
+  ),
+}));
+
+jest.mock('./MetricContributor', () => ({
+  __esModule: true,
+  default: () => <div data-testid="metric-contributor" />,
+}));
+
+jest.mock('./MetricIssue', () => ({
+  __esModule: true,
+  default: () => <div data-testid="metric-issue" />,
+}));
+
+jest.mock('./MetricPr', () => ({
+  __esModule: true,
+  default: () => <div data-testid="metric-pr" />,
+}));
+
+const useLabelStatusMock = jest.fn();
+jest.mock('@modules/analyze/hooks/useLabelStatus', () => ({
+  __esModule: true,
+  default: () => useLabelStatusMock(),
+}));
+
+const verifiedItem = {
+  label: 'octocat/hello-world',
+  level: 'community',
+  status: 'success',
+  shortCode: 'abc123',
+} as any;
+
+describe('MetricDetail', () => {
+  it('renders nothing when no verified item exists', () => {
+    // 回归点：verifiedItems 为空（无效 shortCode / 分析失败）时必须渲染 null。
+    // 旧代码 length > 1 才拦下，空数组继续渲染，子组件解构 verifiedItems[0] 崩溃
+    useLabelStatusMock.mockReturnValue({
+      isLoading: false,
+      status: '',
+      notFound: true,
+      verifiedItems: [],
+    });
+
+    const { container } = render(<MetricDetail />);
+
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders the contributor tab for a single verified item', () => {
+    useLabelStatusMock.mockReturnValue({
+      isLoading: false,
+      status: 'success',
+      notFound: false,
+      verifiedItems: [verifiedItem],
+    });
+
+    const { getByTestId } = render(<MetricDetail />);
+
+    expect(getByTestId('metric-contributor')).toBeInTheDocument();
+  });
+
+  it('renders nothing in compare mode (more than one verified item)', () => {
+    useLabelStatusMock.mockReturnValue({
+      isLoading: false,
+      status: 'progress',
+      notFound: false,
+      verifiedItems: [verifiedItem, verifiedItem],
+    });
+
+    const { container } = render(<MetricDetail />);
+
+    expect(container.innerHTML).toBe('');
+  });
+});

--- a/apps/web/src/modules/analyze/DataView/MetricDetail/index.tsx
+++ b/apps/web/src/modules/analyze/DataView/MetricDetail/index.tsx
@@ -31,7 +31,9 @@ const MetricDetail = () => {
   const queryTab = router.query?.tab as string;
   const { isLoading, verifiedItems } = useLabelStatus();
   const [tab, setTab] = useState<string>(queryTab || 'contributor');
-  if (isLoading || verifiedItems.length > 1) {
+  // verifiedItems 为空（如无效 shortCode 或校验失败）时子组件会对
+  // verifiedItems[0] 解构导致整页崩溃，这里必须一并拦下
+  if (isLoading || verifiedItems.length !== 1) {
     return null;
   }
 


### PR DESCRIPTION
## Problem

`MetricDetail/index.tsx` bails out only while loading or in compare mode:

```ts
if (isLoading || verifiedItems.length > 1) return null;
```

`useLabelStatus()` returns `verifiedItems: []` when the status-verify query yields nothing usable — e.g. an invalid `shortCode` in `/analyze/insight/<shortCode>`, or an analysis whose status is `failed`/`error`. In that case the page renders anyway and the three child tabs do:

```ts
const { label, level } = verifiedItems[0]; // TypeError
```

(`MetricContributor/index.tsx:23`, `MetricIssue/index.tsx:19`, `MetricPr/index.tsx:19`) → *“Cannot destructure property 'label' of undefined”*, the whole page falls into the error boundary.

## Fix

Treat `verifiedItems.length !== 1` as nothing-to-render (single-project view requires exactly one verified item; 0 → nothing, >1 → compare mode, as before).

## Verification

- `yarn test:ci`, `yarn build` pass.

中文说明：访问无效/失败状态的 `/analyze/insight/<shortCode>` 时，`verifiedItems` 为空数组但页面仍会渲染，子组件对 `verifiedItems[0]` 解构导致整页崩溃。统一改为 `length !== 1` 时不渲染。

## Update (testability & evidence)

Added `MetricDetail/index.test.tsx` (hooks and child tabs mocked):

- empty `verifiedItems` → renders nothing (**fails on `main`**, which rendered the page and crashed in the real children)
- single verified item → contributor tab renders
- two verified items (compare mode) → renders nothing (existing behavior preserved)

Local runtime reproduction needs a live GraphQL backend, so this render-decision regression test is the executable evidence.

**Test results:** `yarn test:ci` 16 suites / 54 tests pass; `tsc --noEmit` 0 errors; prettier clean.