### PR TITLE
fix: canceling sort on PR / Issue tables keeps sending desc order

### DIFF
--- a/apps/web/src/modules/analyze/DataView/MetricDetail/MetricIssue/IssueTable.tsx
+++ b/apps/web/src/modules/analyze/DataView/MetricDetail/MetricIssue/IssueTable.tsx
@@ -81,7 +81,9 @@ const MetricTable: React.FC<{
   ) => {
     let sortOpts = null;
     let filterOpts = [];
-    sortOpts = sorter.field && {
+    // 以 sorter.order 为准：第三次点击表头取消排序时 order 为 undefined，
+    // 需要清空排序条件，而不是继续按 desc 发送
+    sortOpts = sorter.order && {
       type: toUnderline(sorter.field as string),
       direction: sorter.order === 'ascend' ? 'asc' : 'desc',
     };

--- a/apps/web/src/modules/analyze/DataView/MetricDetail/MetricPr/PrTable.tsx
+++ b/apps/web/src/modules/analyze/DataView/MetricDetail/MetricPr/PrTable.tsx
@@ -80,7 +80,9 @@ const MetricTable: React.FC<{
   ) => {
     let sortOpts = null;
     let filterOpts = [];
-    sortOpts = sorter.field && {
+    // 以 sorter.order 为准：第三次点击表头取消排序时 order 为 undefined，
+    // 需要清空排序条件，而不是继续按 desc 发送
+    sortOpts = sorter.order && {
       type: toUnderline(sorter.field as string),
       direction: sorter.order === 'ascend' ? 'asc' : 'desc',
     };


### PR DESCRIPTION
## Problem

`handleTableChange` in `MetricPr/PrTable.tsx` and `MetricIssue/IssueTable.tsx` builds the sort option from `sorter.field`:

```ts
sortOpts = sorter.field && {
  type: toUnderline(sorter.field as string),
  direction: sorter.order === 'ascend' ? 'asc' : 'desc',
};
```

When a user clicks a sortable column a third time (antd “cancel sort”), `sorter.order` becomes `undefined` while `sorter.field` is still set, so the query carries `{ type, direction: 'desc' }` — the table stays sorted by that column even though the header shows no sort and the user expected the default order. `ContributorTable/index.tsx` already keys off `sorter.order`; the PR and Issue tables diverge from it.

## Fix

`sortOpts = sorter.order && { ... }` in both tables, matching the contributor table: cancel sort → `sortOpts` stays `null` and the default backend order is used.

## Verification

- `yarn test:ci`, `yarn build` pass.

中文说明：PR / Issue 表格的排序条件用 `sorter.field` 判断，第三次点击表头取消排序时仍会把 `direction: 'desc'` 发给后端，“取消排序”实际不生效。改为与 contributor 表格一致的 `sorter.order` 判断。

## Behavior table (antd sorter states)

| header interaction | sorter.order | old sortOpts sent | new sortOpts sent |
| --- | --- | --- | --- |
| 1st click | `ascend` | `{type, direction:'asc'}` | same |
| 2nd click | `descend` | `{type, direction:'desc'}` | same |
| 3rd click (cancel sort) | `undefined` | **`{type, direction:'desc'}` ← bug: still sorted** | `null` → backend default order |
| page / filter change without sort interaction | `undefined` (no `field`) | `undefined` (no sort, OK) | `null` (same effect) |

The table cells the bug: only the cancel path changes; everything else is byte-identical.

**Test results:** `yarn test:ci` 16 suites / 51 tests pass; `tsc --noEmit` 0 errors; prettier clean.