### PR TITLE
fix: stale member / invitation lists after invite, cancel or remove

### DIFF
--- a/apps/web/src/modules/lab/model/User/index.tsx
+++ b/apps/web/src/modules/lab/model/User/index.tsx
@@ -12,7 +12,6 @@ import {
 } from '@oss-compass/graphql';
 import gqlClient from '@common/gqlClient';
 import useEventEmitter from 'ahooks/lib/useEventEmitter';
-import { ReFetch } from '@common/constant';
 import { useTranslation } from 'react-i18next';
 
 const per = 6;
@@ -40,12 +39,12 @@ const UserManage = () => {
 
   const inviteUsers = useRef(null);
   const event$ = useEventEmitter<string>();
-  event$.useSubscription((flag) => {
-    if (flag === ReFetch) {
-      refetch();
-    } else {
-      inviteUsers.current?.refetch();
-    }
+  // 成员列表里包含“等待确认加入”的被邀请人，两个列表相互依赖：
+  // 发出/取消邀请、删除成员、修改权限后都需要同时刷新两边，
+  // 否则其中一边会停留在旧状态（如已取消的邀请仍显示在待确认列表）
+  event$.useSubscription(() => {
+    refetch();
+    inviteUsers.current?.refetch();
   });
 
   if (isLoading) {


### PR DESCRIPTION
## Problem

In the lab model member management page, the parent subscription dispatches on the event name:

```ts
event$.useSubscription((flag) => {
  if (flag === ReFetch) { refetch(); }          // member list only
  else { inviteUsers.current?.refetch(); }      // invitation list only
});
```

But the two lists depend on each other:

- `FormInvite` (after inviting) emits `'Invite'` → only the invitation list refreshes, while `memberOverview` also renders invited-but-not-joined members (“等待确认加入”) → the new invitee is missing from the member cards until a manual reload.
- `FormUsersItem` emits `ReFetch` on **cancel invitation**, **remove member** and **permission change** → only the member list refreshes, so a canceled invitation stays visible (and re-actionable) under “members to be added” (`FormInviteUsers`).

## Fix

Refresh both lists on every event — the two views always reflect the same underlying member/invitation state, so selective refresh is never desired here.

## Verification

- `yarn test:ci`, `yarn build` pass.

中文说明：实验室成员管理页的事件分发是错位的：发出邀请只刷新“待确认”列表不刷新成员列表（成员列表包含等待确认的邀请人），而取消邀请/删除成员/改权限只刷新成员列表不刷新“待确认”列表（已取消的邀请仍然显示且可再次操作）。统一为每次事件同时刷新两个列表。

## Event → refresh mapping

| action | event emitted | member list (old) | invitation list (old) | after fix |
| --- | --- | --- | --- | --- |
| send invitation (`FormInvite`) | `'Invite'` | stale ❌ (new invitee missing from member cards) | refreshed | both refreshed |
| cancel invitation (`FormUsersItem`) | `ReFetch` | refreshed | stale ❌ (canceled invite still listed / re-actionable) | both refreshed |
| remove member | `ReFetch` | refreshed | stale ❌ | both refreshed |
| change permission | `ReFetch` | refreshed | stale ❌ | both refreshed |

**Test results:** `yarn test:ci` 16 suites / 51 tests pass; `tsc --noEmit` 0 errors; prettier clean.