### PR TITLE
fix: chart render crash when a summary stat is null

### DIFF
--- a/apps/web/src/common/transform/transSummaryToAxis.test.tsx
+++ b/apps/web/src/common/transform/transSummaryToAxis.test.tsx
@@ -1,5 +1,71 @@
 import transSummaryToAxis from './transSummaryToAxis';
 
 describe('transSummaryToAxis', () => {
-  it('transSummaryToAxis', function () {});
+  const xAxis = ['2024-01-01', '2024-02-01'];
+
+  const buildSummary = (rows: any[]) => ({
+    summaryActivity: rows,
+  });
+
+  it('maps mean / median values onto the x axis', () => {
+    const data = buildSummary([
+      {
+        grimoireCreationDate: '2024-01-01',
+        updatedSince: { mean: 1.5, median: 1 },
+      },
+      {
+        grimoireCreationDate: '2024-02-01',
+        updatedSince: { mean: 3, median: 2.25 },
+      },
+    ]);
+
+    expect(
+      transSummaryToAxis(data as any, xAxis, 'summaryActivity.updatedSince')
+    ).toEqual({
+      summaryMean: [1.5, 3],
+      summaryMedian: [1, 2.25],
+    });
+  });
+
+  it('renders "-" for months without data', () => {
+    const data = buildSummary([
+      {
+        grimoireCreationDate: '2024-01-01',
+        updatedSince: { mean: 1.5, median: 1 },
+      },
+    ]);
+
+    expect(
+      transSummaryToAxis(data as any, xAxis, 'summaryActivity.updatedSince')
+    ).toEqual({
+      summaryMean: [1.5, '-'],
+      summaryMedian: [1, '-'],
+    });
+  });
+
+  it('does not throw when the stat object is null (allowed by the schema)', () => {
+    const data = buildSummary([
+      { grimoireCreationDate: '2024-01-01', updatedSince: null },
+      {
+        grimoireCreationDate: '2024-02-01',
+        updatedSince: { mean: 3, median: 2 },
+      },
+    ]);
+
+    expect(
+      transSummaryToAxis(data as any, xAxis, 'summaryActivity.updatedSince')
+    ).toEqual({
+      summaryMean: ['-', 3],
+      summaryMedian: ['-', 2],
+    });
+  });
+
+  it('returns null summary when data is null', () => {
+    expect(
+      transSummaryToAxis(null, xAxis, 'summaryActivity.updatedSince')
+    ).toEqual({
+      summaryMean: ['-', '-'],
+      summaryMedian: ['-', '-'],
+    });
+  });
 });

--- a/apps/web/src/common/transform/transSummaryToAxis.tsx
+++ b/apps/web/src/common/transform/transSummaryToAxis.tsx
@@ -16,6 +16,9 @@ function getSummaryMap(
   const metric = summaryData[firstKey];
   metric.forEach((i: any) => {
     const xAxis = i[xKey] as string;
+    // 统计字段在 schema 中可为 null，此时该月份无数据，
+    // 跳过即可，下游会按 undefined 渲染 '-'
+    if (!i || !i[secondKey]) return;
     const yAxis = i[secondKey] as { mean: number; median: number };
     summaryDateMap.set(xAxis, { mean: yAxis['mean'], median: yAxis['median'] });
   });


### PR DESCRIPTION
## Problem

`common/transform/transSummaryToAxis.tsx` dereferences every summary row's stat object directly:

```ts
const yAxis = i[secondKey] as { mean: number; median: number };
summaryDateMap.set(xAxis, { mean: yAxis['mean'], median: yAxis['median'] });
```

Every summary stat field is nullable in the GraphQL schema (e.g. `commitFrequency?: Maybe<MetricStat>` in `packages/graphql/src/generated.ts`), so a single month whose stat is `null` throws *“Cannot read properties of null (reading 'mean')”* inside a `useMemo` render path and blanks the whole chart card (`ChartWithData` / `ChartDataProvider` and the developer-module copies all funnel through this function, covering dozens of metric cards).

The downstream code already handles missing map entries (`summaryItem?.mean === undefined` → `'-'`), only the upstream dereference is unguarded.

## Fix

Skip rows whose stat object is falsy (they simply have no data that month) and add real test cases to the previously empty `transSummaryToAxis.test.tsx` (value mapping, missing months → `'-'`, **null stat must not throw**, null data).

## Verification

- `yarn test:ci`: all suites pass including the new cases. `yarn build` passes.

中文说明：`transSummaryToAxis` 对 summary 统计对象直接解引用，而 schema 中统计字段均可为 null，任一月份统计为 null 就会在渲染期抛 TypeError 使整张图表崩溃。修复为跳过 null 统计行（下游本就按缺失渲染 '-'），并补充了原本为空壳的单元测试。