### PR TITLE
fix: invalid SVG download URL for cards without a metric mapping

### DIFF
--- a/apps/web/src/modules/analyze/components/DownloadAndShare.tsx
+++ b/apps/web/src/modules/analyze/components/DownloadAndShare.tsx
@@ -17,57 +17,8 @@ import * as RadioGroup from '@radix-ui/react-radio-group';
 import DownCardLoadImage from './DownCardLoadImage';
 import { AiOutlineLoading } from 'react-icons/ai';
 import useCompareItems from '@modules/analyze/hooks/useCompareItems';
-import useQueryDateRange from '@modules/analyze/hooks/useQueryDateRange';
-import { rangeTags } from '../constant';
-import { format } from 'date-fns';
-import { toUnderline } from '@common/utils/format';
+import { useGetSvgUrl } from './useGetSvgUrl';
 
-const queryMap = {
-  metricCodequality: 'collab_dev_index',
-  metricCommunity: 'community',
-  metricActivity: 'activity',
-  metricGroupActivity: 'organizations_activity',
-};
-
-const useGetSvgUrl = (
-  slug: string,
-  id: string,
-  yAxisScale: boolean,
-  onePointSys: boolean,
-  yKey: string
-) => {
-  const { range, timeStart, timeEnd } = useQueryDateRange();
-  let url = `/chart/${slug}.svg`;
-  let metrc = '';
-  let field = '';
-  if (id === 'topic_overview') {
-    metrc = 'overview';
-  } else {
-    const [metrcKey, fieldKey] = yKey.split('.');
-    metrc = queryMap[metrcKey];
-    if (id.indexOf('overview') === -1) {
-      field = toUnderline(fieldKey);
-    }
-  }
-  metrc && (url += `?metric=${metrc}`);
-  field && (url += `&field=${field}`);
-  !onePointSys && (url += `&y_trans=1`);
-  !yAxisScale && (url += `&y_abs=1`);
-  if (
-    id === 'code_quality_is_maintained' ||
-    id === 'code_quality_loc_frequency'
-  ) {
-    url += `&chart=bar`;
-  }
-  if (rangeTags.includes(range)) {
-    url += `&range=${range}`;
-  } else {
-    const begin_date = format(timeStart!, 'yyyy-MM-dd');
-    const end_date = format(timeEnd!, 'yyyy-MM-dd');
-    url += `&begin_date=${begin_date}&end_date=${end_date}`;
-  }
-  return url;
-};
 const DownloadAndShare = (props: {
   cardRef: RefObject<HTMLElement>;
   downloadImageSize?: 'middle' | 'full';

--- a/apps/web/src/modules/analyze/components/useGetSvgUrl.test.tsx
+++ b/apps/web/src/modules/analyze/components/useGetSvgUrl.test.tsx
@@ -1,0 +1,82 @@
+import { renderHook } from '@testing-library/react';
+import { useRouter } from 'next/router';
+import { useGetSvgUrl } from './useGetSvgUrl';
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}));
+
+jest.mock('@modules/analyze/hooks/useVerifyDetailRangeQuery', () => ({
+  __esModule: true,
+  default: () => ({ isLoading: false, data: undefined }),
+}));
+
+const mockRouter = (query: Record<string, string>) => {
+  (useRouter as jest.Mock).mockReturnValue({ query });
+};
+
+describe('useGetSvgUrl', () => {
+  it('joins params with a single leading ? for mapped metrics', () => {
+    mockRouter({ range: '6M' });
+    const { result } = renderHook(() =>
+      useGetSvgUrl(
+        'abc123',
+        'commit_frequency',
+        true,
+        true,
+        'metricActivity.commitFrequency'
+      )
+    );
+
+    expect(result.current).toBe(
+      '/chart/abc123.svg?metric=activity&field=commit_frequency&range=6M'
+    );
+  });
+
+  it('starts the query string with ? when the metric has no mapping', () => {
+    // 回归点：贡献者画像指标不在 queryMap 中，旧实现会把第一个参数
+    // 以 & 拼进路径，生成 /chart/<slug>.svg&field=... 的非法 URL
+    mockRouter({ range: '6M' });
+    const { result } = renderHook(() =>
+      useGetSvgUrl(
+        'abc123',
+        'activity_core_count',
+        true,
+        true,
+        'metricMilestonePersona.activityCoreContributorCount'
+      )
+    );
+
+    expect(result.current).toBe(
+      '/chart/abc123.svg?field=activity_core_contributor_count&range=6M'
+    );
+  });
+
+  it('builds the overview url and keeps param order', () => {
+    mockRouter({ range: '6M' });
+    const { result } = renderHook(() =>
+      useGetSvgUrl('abc123', 'topic_overview', false, false, 'metricActivity.x')
+    );
+
+    expect(result.current).toBe(
+      '/chart/abc123.svg?metric=overview&y_trans=1&y_abs=1&range=6M'
+    );
+  });
+
+  it('appends chart=bar for bar chart cards', () => {
+    mockRouter({ range: '6M' });
+    const { result } = renderHook(() =>
+      useGetSvgUrl(
+        'abc123',
+        'code_quality_is_maintained',
+        true,
+        true,
+        'metricCodequality.isMaintained'
+      )
+    );
+
+    expect(result.current).toBe(
+      '/chart/abc123.svg?metric=collab_dev_index&field=is_maintained&chart=bar&range=6M'
+    );
+  });
+});

--- a/apps/web/src/modules/analyze/components/useGetSvgUrl.ts
+++ b/apps/web/src/modules/analyze/components/useGetSvgUrl.ts
@@ -1,0 +1,55 @@
+import useQueryDateRange from '@modules/analyze/hooks/useQueryDateRange';
+import { rangeTags } from '../constant';
+import { format } from 'date-fns';
+import { toUnderline } from '@common/utils/format';
+
+const queryMap = {
+  metricCodequality: 'collab_dev_index',
+  metricCommunity: 'community',
+  metricActivity: 'activity',
+  metricGroupActivity: 'organizations_activity',
+};
+
+export const useGetSvgUrl = (
+  slug: string,
+  id: string,
+  yAxisScale: boolean,
+  onePointSys: boolean,
+  yKey: string
+) => {
+  const { range, timeStart, timeEnd } = useQueryDateRange();
+  let url = `/chart/${slug}.svg`;
+  const params: string[] = [];
+  let metrc = '';
+  let field = '';
+  if (id === 'topic_overview') {
+    metrc = 'overview';
+  } else {
+    const [metrcKey, fieldKey] = yKey.split('.');
+    metrc = queryMap[metrcKey];
+    if (id.indexOf('overview') === -1) {
+      field = toUnderline(fieldKey);
+    }
+  }
+  metrc && params.push(`metric=${metrc}`);
+  field && params.push(`field=${field}`);
+  !onePointSys && params.push(`y_trans=1`);
+  !yAxisScale && params.push(`y_abs=1`);
+  if (
+    id === 'code_quality_is_maintained' ||
+    id === 'code_quality_loc_frequency'
+  ) {
+    params.push(`chart=bar`);
+  }
+  if (rangeTags.includes(range)) {
+    params.push(`range=${range}`);
+  } else {
+    const begin_date = format(timeStart!, 'yyyy-MM-dd');
+    const end_date = format(timeEnd!, 'yyyy-MM-dd');
+    params.push(`begin_date=${begin_date}`, `end_date=${end_date}`);
+  }
+  if (params.length > 0) {
+    url += `?${params.join('&')}`;
+  }
+  return url;
+};


### PR DESCRIPTION
## Problem

`useGetSvgUrl` in `modules/analyze/components/DownloadAndShare.tsx` appends `?metric=` only when the metric exists in `queryMap` (which only covers `collab_dev_index` / `community` / `activity` / `organizations_activity`), then joins every following param with `&`:

```ts
metrc && (url += `?metric=${metrc}`);
field && (url += `&field=${field}`);
!onePointSys && (url += `&y_trans=1`);
```

Contributor persona cards (`metricMilestonePersona.*`, `metricContributionPersona.*`, …, e.g. `DataView/Contributor/ContributorMilestonePersona/ActivityCoreCount.tsx`) are not in `queryMap`, so their first param is glued onto the path: `/chart/<slug>.svg&field=activity_core_contributor_count&y_trans=1&...`. The `&` becomes part of the path → 404. The Markdown / HTML / Link snippets in the download dialog for those cards are all broken.

## Fix

Collect the query params in order and join them with a single leading `?`. Output for cards with a metric mapping is byte-identical; cards without one now produce well-formed URLs (`?field=...`).

## Verification

- `yarn test:ci`, `yarn build` pass.

中文说明：下载/分享弹窗生成 SVG 链接时，若指标的 `yKey` 不在 `queryMap`（所有贡献者画像类指标），第一个参数会用 `&` 拼接、生成 `/chart/<slug>.svg&field=...` 这类非法 URL（`&` 进了路径导致 404）。改为统一收集参数后以单个 `?` 拼接，已映射指标的输出不变。

## Update (testability & evidence)

`useGetSvgUrl` moved to `components/useGetSvgUrl.ts` (the card imports it; URL output unchanged) and is covered by `useGetSvgUrl.test.tsx`:

- mapped metric → `?metric=activity&field=commit_frequency&range=6M` (byte-identical to the old output)
- persona metric without mapping → `?field=activity_core_contributor_count&range=6M` — the old code produced `/chart/<slug>.svg&field=...` (**test fails on `main`**)
- `topic_overview`, `y_trans=1` / `y_abs=1` flags and `chart=bar` ordering preserved

**Test results:** `yarn test:ci` 17 suites / 55 tests pass; `tsc --noEmit` 0 errors; prettier clean.