### PR TITLE
fix: 'stage' column sorting is a no-op in the pain detail modal

### DIFF
--- a/apps/web/src/modules/intelligent-analysis/DeveloperExperience/IssueContribution/components/IssueOverview/IssuePainDetailModal.tsx
+++ b/apps/web/src/modules/intelligent-analysis/DeveloperExperience/IssueContribution/components/IssueOverview/IssuePainDetailModal.tsx
@@ -116,6 +116,9 @@ const IssuePainDetailModal: React.FC<Props> = ({
         if (sortKey === 'repo') return item.repoShort;
         if (sortKey === 'team') return repoTeams[item.repoShort] || '';
         if (sortKey === 'state') return getPainStateLabel(item);
+        // 类型上只有 stageName 字段，sortKey 'stage' 需显式映射，
+        // 否则落到 item['stage']（不存在）后所有行排序值都是空串
+        if (sortKey === 'stage') return item.stageName || '';
         return String(item[sortKey] || '');
       };
       const left = sortValue(a);


### PR DESCRIPTION
## Problem

In `IssuePainDetailModal` (opened from the issue overview page), the 阶段 (stage) column header is registered as sortable with `sortKey 'stage'`, but the sort comparator falls through to `item[sortKey]`:

```ts
const sortValue = (item: IssueOverviewTopPain) => {
  if (sortKey === 'repo') return item.repoShort;
  if (sortKey === 'team') return repoTeams[item.repoShort] || '';
  if (sortKey === 'state') return getPainStateLabel(item);
  return String(item[sortKey] || '');   // sortKey 'stage' → item['stage'] → undefined
};
```

`IssueOverviewTopPain` has no `stage` field — the correct field is `stageName` (the stage filter in the same modal already uses `item.stageName`). Every row therefore sorts as an empty string: clicking the 阶段 header shows an active ↑/↓ arrow but the row order never changes.

## Fix

Map the key explicitly: `if (sortKey === 'stage') return item.stageName || '';`

## Verification

- `yarn test:ci` (51 tests) and `tsc --noEmit` pass.

中文说明：痛点详情弹窗的“阶段”列排序用了不存在的字段名 `item.stage`（正确字段是 `stageName`），所有行排序值都是空串，点击表头箭头变化但顺序永远不变。