### PR TITLE
fix: pain tracking steps show terminal states as 'in progress' with duplicated timestamps

### DIFF
--- a/apps/web/src/modules/intelligent-analysis/DeveloperExperience/IssueContribution/components/PainTrackingModal/index.tsx
+++ b/apps/web/src/modules/intelligent-analysis/DeveloperExperience/IssueContribution/components/PainTrackingModal/index.tsx
@@ -12,69 +12,7 @@ import {
   shortTrackingPeriod,
   validateOperator,
 } from './utils';
-
-const getCurrentFlowStep = (
-  status: IssuePainTrackingStatus,
-  isObserve: boolean
-) => {
-  if (status === IssuePainTrackingStatus.PENDING) return 0;
-  if (status === IssuePainTrackingStatus.TRACKING) return 1;
-  if (status === IssuePainTrackingStatus.FIXED_PENDING_RETEST) return 2;
-  if (status === IssuePainTrackingStatus.PASSED) return isObserve ? 2 : 3;
-  if (status === IssuePainTrackingStatus.RETEST_FAILED) return 3;
-  return 1;
-};
-
-const findStatusTime = (
-  tracking: IssuePainTracking,
-  status: IssuePainTrackingStatus
-) =>
-  [...tracking.history].reverse().find((item) => item.to === status)?.at ??
-  null;
-
-const createFlowItem = (title: string, time?: string | null) => ({
-  title,
-  description: time ? (
-    <span className="text-xs text-slate-500">{formatTrackingTime(time)}</span>
-  ) : null,
-});
-
-const createPendingFlowItem = (tracking: IssuePainTracking) => {
-  return createFlowItem('待确认', tracking.confirmedAt);
-};
-
-const getFlowItems = (tracking: IssuePainTracking, isObserve: boolean) => {
-  if (tracking.status === IssuePainTrackingStatus.INVALID) {
-    const invalidAt = findStatusTime(tracking, IssuePainTrackingStatus.INVALID);
-    return [
-      createPendingFlowItem(tracking),
-      createFlowItem('非有效问题', invalidAt),
-    ];
-  }
-  if (isObserve) {
-    return [
-      createPendingFlowItem(tracking),
-      createFlowItem('已确认待修复', tracking.confirmedAt),
-      createFlowItem('已闭环', tracking.retest?.at),
-    ];
-  }
-  const retestFailed =
-    tracking.status === IssuePainTrackingStatus.RETEST_FAILED;
-  return [
-    createPendingFlowItem(tracking),
-    createFlowItem('已确认待修复', tracking.confirmedAt),
-    createFlowItem(
-      '已修复待复测',
-      findStatusTime(tracking, IssuePainTrackingStatus.FIXED_PENDING_RETEST)
-    ),
-    createFlowItem(
-      retestFailed ? '复测不通过' : '已复测通过',
-      retestFailed
-        ? findStatusTime(tracking, IssuePainTrackingStatus.RETEST_FAILED)
-        : tracking.retest?.at
-    ),
-  ];
-};
+import { getCurrentFlowStep, getFlowItems } from './steps';
 
 const getFixProgressPercent = (tracking: IssuePainTracking) =>
   tracking.activeTotal

--- a/apps/web/src/modules/intelligent-analysis/DeveloperExperience/IssueContribution/components/PainTrackingModal/steps.test.tsx
+++ b/apps/web/src/modules/intelligent-analysis/DeveloperExperience/IssueContribution/components/PainTrackingModal/steps.test.tsx
@@ -1,0 +1,102 @@
+import { getCurrentFlowStep, getFlowItems } from './steps';
+import { IssuePainTrackingStatus } from '../../types';
+import { formatTrackingTime } from './utils';
+import type { IssuePainTracking } from '../../types';
+
+const CONFIRMED_AT = '2026-01-02T12:00:00Z';
+const RETEST_AT = '2026-03-01T12:00:00Z';
+const INVALID_AT = '2026-01-05T12:00:00Z';
+
+const buildTracking = (
+  partial: Partial<IssuePainTracking>
+): IssuePainTracking =>
+  ({
+    status: IssuePainTrackingStatus.PENDING,
+    confirmedAt: CONFIRMED_AT,
+    history: [],
+    retest: null,
+    ...partial,
+  } as IssuePainTracking);
+
+const descriptionText = (item: { description: any }) => {
+  if (item.description === null) return null;
+  // createFlowItem 的 description 是 <span>{formatTrackingTime(time)}</span>
+  return item.description.props.children;
+};
+
+describe('getCurrentFlowStep', () => {
+  it('maps each in-flight status to its step', () => {
+    expect(getCurrentFlowStep(IssuePainTrackingStatus.PENDING, false)).toBe(0);
+    expect(getCurrentFlowStep(IssuePainTrackingStatus.TRACKING, false)).toBe(1);
+    expect(
+      getCurrentFlowStep(IssuePainTrackingStatus.FIXED_PENDING_RETEST, false)
+    ).toBe(2);
+    expect(
+      getCurrentFlowStep(IssuePainTrackingStatus.RETEST_FAILED, false)
+    ).toBe(3);
+  });
+
+  it('marks terminal statuses as fully finished', () => {
+    // 回归点：PASSED 之前返回 isObserve ? 2 : 3（最后一步下标），
+    // 终态被渲染成“进行中”，且终步说明时间被剥离规则丢弃
+    expect(getCurrentFlowStep(IssuePainTrackingStatus.PASSED, false)).toBe(4);
+    expect(getCurrentFlowStep(IssuePainTrackingStatus.PASSED, true)).toBe(3);
+    expect(getCurrentFlowStep(IssuePainTrackingStatus.INVALID, false)).toBe(2);
+  });
+});
+
+describe('getFlowItems', () => {
+  it('pending step carries no timestamp, confirmed time belongs to step 2', () => {
+    // 回归点：待确认 / 已确认待修复 两步之前都渲染 confirmedAt
+    const items = getFlowItems(
+      buildTracking({ status: IssuePainTrackingStatus.TRACKING }),
+      false
+    );
+
+    expect(items.map((item) => item.title)).toEqual([
+      '待确认',
+      '已确认待修复',
+      '已修复待复测',
+      '已复测通过',
+    ]);
+    expect(descriptionText(items[0])).toBeNull();
+    expect(descriptionText(items[1])).toBe(formatTrackingTime(CONFIRMED_AT));
+    expect(descriptionText(items[2])).toBeNull();
+    expect(descriptionText(items[3])).toBeNull();
+  });
+
+  it('passed flow shows the retest time on the final step', () => {
+    const items = getFlowItems(
+      buildTracking({
+        status: IssuePainTrackingStatus.PASSED,
+        retest: { decision: 'passed', auto: true, at: RETEST_AT },
+      }),
+      false
+    );
+
+    expect(descriptionText(items[3])).toBe(formatTrackingTime(RETEST_AT));
+  });
+
+  it('invalid flow shows the invalid transition time', () => {
+    const items = getFlowItems(
+      buildTracking({
+        status: IssuePainTrackingStatus.INVALID,
+        history: [
+          {
+            at: INVALID_AT,
+            by: 'alice',
+            action: 'mark_invalid',
+            from: IssuePainTrackingStatus.PENDING,
+            to: IssuePainTrackingStatus.INVALID,
+            reason: 'not a real pain',
+            latestTitle: 'pain',
+          },
+        ],
+      }),
+      false
+    );
+
+    expect(items.map((item) => item.title)).toEqual(['待确认', '非有效问题']);
+    expect(descriptionText(items[1])).toBe(formatTrackingTime(INVALID_AT));
+  });
+});

--- a/apps/web/src/modules/intelligent-analysis/DeveloperExperience/IssueContribution/components/PainTrackingModal/steps.tsx
+++ b/apps/web/src/modules/intelligent-analysis/DeveloperExperience/IssueContribution/components/PainTrackingModal/steps.tsx
@@ -1,0 +1,71 @@
+import type { IssuePainTracking } from '../../types';
+import { IssuePainTrackingStatus } from '../../types';
+import { formatTrackingTime } from './utils';
+
+export const getCurrentFlowStep = (
+  status: IssuePainTrackingStatus,
+  isObserve: boolean
+) => {
+  if (status === IssuePainTrackingStatus.PENDING) return 0;
+  if (status === IssuePainTrackingStatus.TRACKING) return 1;
+  if (status === IssuePainTrackingStatus.FIXED_PENDING_RETEST) return 2;
+  // 终态（复测通过 / 非有效问题）流程已走完：
+  // current 指到步数上限，最后一步按完成态渲染，说明时间也得以展示
+  if (status === IssuePainTrackingStatus.PASSED) return isObserve ? 3 : 4;
+  if (status === IssuePainTrackingStatus.INVALID) return 2;
+  if (status === IssuePainTrackingStatus.RETEST_FAILED) return 3;
+  return 1;
+};
+
+export const findStatusTime = (
+  tracking: IssuePainTracking,
+  status: IssuePainTrackingStatus
+) =>
+  [...tracking.history].reverse().find((item) => item.to === status)?.at ??
+  null;
+
+export const createFlowItem = (title: string, time?: string | null) => ({
+  title,
+  description: time ? (
+    <span className="text-xs text-slate-500">{formatTrackingTime(time)}</span>
+  ) : null,
+});
+
+// “待确认”阶段的开始时间没有记录（confirmedAt 是确认发生的时刻，
+// 属于下一步），置空避免与“已确认待修复”显示同一个时间戳
+export const createPendingFlowItem = () => {
+  return createFlowItem('待确认');
+};
+
+export const getFlowItems = (
+  tracking: IssuePainTracking,
+  isObserve: boolean
+) => {
+  if (tracking.status === IssuePainTrackingStatus.INVALID) {
+    const invalidAt = findStatusTime(tracking, IssuePainTrackingStatus.INVALID);
+    return [createPendingFlowItem(), createFlowItem('非有效问题', invalidAt)];
+  }
+  if (isObserve) {
+    return [
+      createPendingFlowItem(),
+      createFlowItem('已确认待修复', tracking.confirmedAt),
+      createFlowItem('已闭环', tracking.retest?.at),
+    ];
+  }
+  const retestFailed =
+    tracking.status === IssuePainTrackingStatus.RETEST_FAILED;
+  return [
+    createPendingFlowItem(),
+    createFlowItem('已确认待修复', tracking.confirmedAt),
+    createFlowItem(
+      '已修复待复测',
+      findStatusTime(tracking, IssuePainTrackingStatus.FIXED_PENDING_RETEST)
+    ),
+    createFlowItem(
+      retestFailed ? '复测不通过' : '已复测通过',
+      retestFailed
+        ? findStatusTime(tracking, IssuePainTrackingStatus.RETEST_FAILED)
+        : tracking.retest?.at
+    ),
+  ];
+};


### PR DESCRIPTION
## Problem

Two related defects in the 痛点管理 (pain tracking) modal's Steps timeline (`PainTrackingModal/index.tsx`):

**1. Duplicated timestamps.** The '待确认' step and the '已确认待修复' step both render `tracking.confirmedAt`:

```ts
createFlowItem('待确认', tracking.confirmedAt),      // step 0
createFlowItem('已确认待修复', tracking.confirmedAt), // step 1 — same value
```

`confirmedAt` is the moment the pain was confirmed, i.e. the *end* of the pending phase and the *start* of the tracking phase. After confirmation the two adjacent steps always show the identical timestamp.

**2. Terminal states rendered as 'in progress' with their transition times discarded.** For `PASSED` the flow step equals the last step index (`isObserve ? 2 : 3`), so antd `Steps` renders the final '已复测通过' step as a blue in-progress step — directly contradicting the green “痛点已自动复测通过” Alert rendered above it. The same strip rule (`index >= currentStep → description: null`) then unconditionally discards the descriptions computed for the final step, so `retest?.at` (PASSED) and `invalidAt` (INVALID) are calculated but can never appear — dead data.

## Fix

- The pending step renders without a timestamp (`confirmedAt` stays on the step it belongs to); the pending phase has no recorded start time.
- `getCurrentFlowStep` now returns `items.length` for terminal statuses (`PASSED` → 4 fix / 3 observe, `INVALID` → 2), so every step renders as finished and the final transition time is displayed. `RETEST_FAILED` intentionally stays 'in progress' — the flow genuinely continues (fix again).

## Verification

- `yarn test:ci` (51 tests) and `tsc --noEmit` pass; antd Steps `current === items.length` renders all steps as finishIcon (documented antd semantics).

中文说明：痛点管理弹窗时间线有两个缺陷：①“待确认”和“已确认待修复”两步显示同一个 confirmedAt 时间戳；②终态（已复测通过/非有效问题）被渲染成“进行中”，且为终步计算的 retest.at / invalidAt 时间被渲染规则无条件丢弃，永远显示不出来。修复后终态全部按完成态渲染并展示流转时间。

## Update (testability & evidence)

The step logic (`getCurrentFlowStep`, `getFlowItems`, `createFlowItem`) moved to `PainTrackingModal/steps.tsx` (the modal imports it; logic unchanged) and is covered by `steps.test.tsx`:

- status → step matrix, including `PASSED → 4` (fix flow) / `3` (observe) and `INVALID → 2` — terminal statuses advance past the last step (**fails on `main`**, where the final step rendered as in-progress)
- pending step carries no timestamp; `confirmedAt` belongs to '已确认待修复'; PASSED flow shows `retest.at` on the final step; INVALID flow shows the transition time (both were computed but always stripped before)

**Test results:** `yarn test:ci` 17 suites / 56 tests pass; `tsc --noEmit` 0 errors; prettier clean.