### PR TITLE
fix: stale page renders an empty 'all issue scores' table after data refresh

### DIFF
--- a/apps/web/src/modules/intelligent-analysis/DeveloperExperience/IssueContribution/components/IssueExperiencePath.tsx
+++ b/apps/web/src/modules/intelligent-analysis/DeveloperExperience/IssueContribution/components/IssueExperiencePath.tsx
@@ -189,6 +189,13 @@ const StageIssueScoreSection: React.FC<{
 }> = ({ stageId, entries }) => {
   const [open, setOpen] = useState(true);
   const [page, setPage] = useState(1);
+  // 报告版本切换等场景会整体替换 entries，但父级 key 只含 stageId，
+  // 组件不会重挂载；数据变化时必须回到第 1 页，
+  // 否则旧页码可能越界渲染出空表格（且数据变少时分页器一并消失）
+  const entriesKey = entries.map((entry) => entry.row.number).join(',');
+  useEffect(() => {
+    setPage(1);
+  }, [entriesKey]);
   const lowCount = entries.filter((entry) => entry.score < 60).length;
   const visibleEntries = entries.slice(
     (page - 1) * STAGE_SCORE_PAGE_SIZE,


### PR DESCRIPTION
## Problem

`StageIssueScoreSection` (全部 Issue 得分 table in the stage experience path) is mounted with `key={\`issue-scores-\${activeStage.id}\`}`, so it only remounts when the stage changes. Switching the **report version** replaces `issue_score_rows` wholesale while the stage id stays the same — the component keeps its old `page` state:

- If the previous page number exceeds the new data range, `entries.slice((page-1)*10, page*10)` is empty → the table body renders blank.
- If the new dataset fits in one page, the pagination control disappears too (it is conditionally rendered), leaving a permanently blank table with no way to recover except re-selecting the stage.

The sibling `PainIssueTable` in the same feature already guards against exactly this with an `issueListKey` effect reset; this component missed it.

## Fix

Reset to page 1 whenever the entry set changes (`entries.map(e => e.row.number).join(',')` as the effect key), mirroring the PainIssueTable pattern.

## Verification

- `yarn test:ci` (51 tests) and `tsc --noEmit` pass.

中文说明：切换报告版本会整体替换 Issue 得分数据，但组件 key 只含 stageId 不会重挂载，旧页码越界后表格渲染为空，且数据变少时连分页器都会消失，页面永久卡在空表。参照同功能的 PainIssueTable 增加“数据变化回到第 1 页”的重置逻辑。