### PR TITLE
fix: global import/export dependency wheel never renders on os-situation page

### DIFF
--- a/apps/web/src/modules/os-situation/components/DependencywheelCommon.test.ts
+++ b/apps/web/src/modules/os-situation/components/DependencywheelCommon.test.ts
@@ -1,0 +1,62 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+// jsdom 的 CSS 对象缺少 supports，Highcharts 12 求值时需要它
+(window as any).CSS = (window as any).CSS ?? {};
+(window as any).CSS.supports = (window as any).CSS.supports ?? (() => true);
+
+/**
+ * 高模块加载顺序回归测试。
+ *
+ * 生产事故背景：dependency-wheel 模块在「模块求值时」顶层解构
+ * `SeriesRegistry.seriesTypes.sankey`，如果 sankey 模块尚未注册，
+ * 会抛出 `TypeError: Cannot read properties of undefined (reading 'prototype')`，
+ * 导致 /os-situation/metrics/import_export 页面的依赖关系图永远空白。
+ */
+describe('highcharts dependency-wheel load order', () => {
+  it('throws the production TypeError when dependency-wheel is evaluated before sankey', () => {
+    jest.resetModules();
+    const Highcharts = require('highcharts');
+    // dependency-wheel 在未注册 sankey 时求值，必须抛出与线上一致的错误
+    expect(() => {
+      require('highcharts/modules/dependency-wheel');
+    }).toThrow(
+      new RegExp(
+        "Cannot read properties of undefined \\(reading 'prototype'\\)"
+      )
+    );
+    expect(
+      (Highcharts as any).SeriesRegistry.seriesTypes.dependencywheel
+    ).toBeUndefined();
+    jest.resetModules();
+  });
+
+  it('registers the dependencywheel series when sankey is loaded first', () => {
+    jest.resetModules();
+    require('highcharts');
+    require('highcharts/modules/sankey');
+    require('highcharts/modules/dependency-wheel');
+    const Highcharts = require('highcharts');
+    expect(
+      (Highcharts as any).SeriesRegistry.seriesTypes.dependencywheel
+    ).toBeDefined();
+    jest.resetModules();
+  });
+
+  it('loadHighchartsModules awaits sankey before dependency-wheel', async () => {
+    const source = fs.readFileSync(
+      path.join(__dirname, 'DependencywheelCommon.tsx'),
+      'utf8'
+    );
+    const sankeyIndex = source.indexOf(
+      "await import('highcharts/modules/sankey')"
+    );
+    const wheelIndex = source.indexOf(
+      "await import('highcharts/modules/dependency-wheel')"
+    );
+    expect(sankeyIndex).toBeGreaterThan(-1);
+    expect(wheelIndex).toBeGreaterThan(sankeyIndex);
+    // 防止改回 Promise.all 并行加载的写法
+    expect(source).not.toMatch(/Promise\.all\(\s*\[\s*import\('highcharts/);
+  });
+});

--- a/apps/web/src/modules/os-situation/components/DependencywheelCommon.tsx
+++ b/apps/web/src/modules/os-situation/components/DependencywheelCommon.tsx
@@ -14,13 +14,18 @@ export interface HighchartsDependencyWheelProps {
   _tracing?: string;
 }
 const loadHighchartsModules = async (callback) => {
-  Promise.all([
-    import('highcharts/modules/map'),
-    import('highcharts/modules/sankey'),
-    import('highcharts/modules/dependency-wheel'),
-    import('highcharts/modules/exporting'),
-    import('highcharts/modules/accessibility'),
-  ]).then(callback);
+  try {
+    // dependency-wheel 在模块求值时读取 seriesTypes.sankey，
+    // sankey 必须先于 dependency-wheel 加载完成注册，不能并行加载
+    await import('highcharts/modules/map');
+    await import('highcharts/modules/sankey');
+    await import('highcharts/modules/dependency-wheel');
+    await import('highcharts/modules/exporting');
+    await import('highcharts/modules/accessibility');
+    callback();
+  } catch (error) {
+    console.error('Failed to load Highcharts modules:', error);
+  }
 };
 const DependencywheelCommon: React.FC<HighchartsDependencyWheelProps> = ({
   data,


### PR DESCRIPTION
## Problem

On the Situation Insight product page, the **"Global Open Source Import and Export Contribution"** dependency-wheel chart on `/os-situation/metrics/import_export` never renders — the section stays blank on every page load, and each load throws an uncaught exception:

```
TypeError: Cannot read properties of undefined (reading 'prototype')
```

Reproduction (verified against production, 5/5 page loads):
1. Open https://oss-compass.org/os-situation/metrics/import_export (Home → All Services → Open Source Situation Insight → "Open Source Import and Export Contribution Development Trend").
2. The first card below the info alert stays blank; DevTools console shows the TypeError above; the `#container` div remains an empty `<div style="height: 100%;"></div>`.

## Root cause

`loadHighchartsModules` in `apps/web/src/modules/os-situation/components/DependencywheelCommon.tsx` loaded the five Highcharts module plugins with a **parallel** `Promise.all([...import()])`.

The `dependency-wheel` plugin destructures `SeriesRegistry.seriesTypes.sankey` **at module evaluation time** (`@requires modules/sankey`, highcharts `dependency-wheel.src.js` line 132). With parallel dynamic imports the two chunks are fetched/evaluated concurrently, so when the `dependency-wheel` chunk evaluates before the `sankey` module has registered, the top-level destructuring throws. The `Promise.all` rejects, the `.then(callback)` never runs, `setOptions` is never called — the chart stays blank permanently and every visit logs an unhandled rejection.

The failing chunk on production (`1710.….js`, module `61710`) confirms the throw site: `let {sankey:{prototype:{pointClass:c}}}=p().seriesTypes`.

## Fix

Load the Highcharts modules sequentially and handle load errors:

- `await import('highcharts/modules/sankey')` now completes **before** `await import('highcharts/modules/dependency-wheel')` (the order required by the plugin), so the series type is registered before it is consumed.
- A `try/catch` turns a module load failure into a logged error instead of an unhandled promise rejection that silently kills the chart.

## Tests

New `DependencywheelCommon.test.ts`:

1. **Reproduces the production error**: evaluating `highcharts/modules/dependency-wheel` on a fresh Highcharts instance without sankey registered throws exactly `Cannot read properties of undefined (reading 'prototype')`, and the `dependencywheel` series type is not registered.
2. **Locks the required order**: loading sankey first, then dependency-wheel, registers the `dependencywheel` series type.
3. **Guard**: `loadHighchartsModules` must await sankey before dependency-wheel and must not go back to a parallel `Promise.all` over the imports.

- Fails against the pre-fix component (guard test), passes with the fix.
- Full suite: `18 suites / 72 tests` all passing; eslint and prettier clean on the changed files.

## Risk

Low. The only behavioral change is sequential loading of five small plugin chunks and an added catch; the chart options and rendering path are untouched. The pre-existing `react-hooks/exhaustive-deps` warning on `[loading]` is left as-is.
