### PR TITLE
fix: guard transHundredMarkSystem against non-numeric input

### DIFF
--- a/apps/web/src/common/transform/transHundredMarkSystem.test.ts
+++ b/apps/web/src/common/transform/transHundredMarkSystem.test.ts
@@ -8,6 +8,13 @@ describe('utils number ', () => {
     expect(transHundredMarkSystem(0)).toBe(0);
     expect(transHundredMarkSystem(0.5)).toBe(80);
     expect(transHundredMarkSystem(0.7)).toBe(90);
-    // expect(transHundredMarkSystem(null)).toBeNull();
+  });
+
+  it('transHundredMarkSystem returns "-" for missing / non-numeric input', () => {
+    expect(transHundredMarkSystem('-')).toBe('-');
+    expect(transHundredMarkSystem(null)).toBe('-');
+    expect(transHundredMarkSystem(undefined)).toBe('-');
+    expect(transHundredMarkSystem(NaN)).toBe('-');
+    expect(transHundredMarkSystem('N/A')).toBe('-');
   });
 });

--- a/apps/web/src/common/transform/transHundredMarkSystem.ts
+++ b/apps/web/src/common/transform/transHundredMarkSystem.ts
@@ -29,7 +29,7 @@ const transHundredMarkSystem = (oneMark: number | string): number | string => {
     return '-';
   }
   oneMark = Number(oneMark);
-  if (oneMark < 0 || oneMark > 1) {
+  if (isNaN(oneMark) || oneMark < 0 || oneMark > 1) {
     return '-';
   }
   let index = 0;


### PR DESCRIPTION
## Problem

`transHundredMarkSystem` already returns `'-'` for the `'-'`, `null` and `''` values that backend metric data can contain, but every other non-numeric value crashes the function:

```ts
oneMark = Number(oneMark);            // undefined / 'N/A' -> NaN
if (oneMark < 0 || oneMark > 1) {     // NaN fails both comparisons -> falls through
  return '-';
}
...
index = oneMarkList.findIndex((i) => oneMark >= i[0] && oneMark < i[1]);  // -1
const oneMarkArr = oneMarkList[index];   // undefined
const hundredMarkArr = hundredMarkList[index];
const hundredMark = ((hundredMarkArr[1] - ...                 // TypeError
```

`toHundredMark()` is called from the chart option builders (`analyze` / `developer` `getLineBuilder`, `useGetLineOption`) with metric arrays, so a single malformed summary value would throw while building chart options and take down the whole chart instead of showing a gap.

## Fix

Treat `NaN` like the other invalid values:

```ts
if (isNaN(oneMark) || oneMark < 0 || oneMark > 1) {
  return '-';
}
```

This covers `undefined`, `NaN` and non-numeric strings (all become `NaN` and previously crashed). The old test file already had a commented-out `// expect(transHundredMarkSystem(null)).toBeNull();` hinting at this gap.

## Verification

Verified on `main` @ `5cecc1d63` (Node 22, jest --ci):

- Before: the added test fails with `TypeError: Cannot read properties of undefined (reading '1')`
- After: all transform suites pass; whole `apps/web` suite: **17 suites / 70 tests passed**
- `next lint` on the two changed files: no warnings or errors

---

**AI disclosure:** This change was prepared with AI assistance (GitHub Copilot/Claude-style tooling guided by a human contributor).