### PR TITLE
fix: fillHttps mangles http:// URLs into https://http://...

### DIFF
--- a/apps/web/src/common/utils/url.test.ts
+++ b/apps/web/src/common/utils/url.test.ts
@@ -10,6 +10,7 @@ import {
   removeExtname,
   removeTrailingSlash,
   getNameSpacePng,
+  fillHttps,
 } from './url';
 
 describe('utils url ', () => {
@@ -221,6 +222,34 @@ describe('utils url ', () => {
 
     testCases.map((item) => {
       expect(getNameSpacePng(item.input)).toEqual(item.result);
+    });
+  });
+
+  it('fillHttps', function () {
+    const testCases = [
+      { input: 'github.com/cli/cli', result: 'https://github.com/cli/cli' },
+      {
+        input: 'http://github.com/cli/cli',
+        result: 'https://github.com/cli/cli',
+      },
+      {
+        input: 'https://github.com/cli/cli',
+        result: 'https://github.com/cli/cli',
+      },
+      {
+        input: 'https://github.com/cli/cli/',
+        result: 'https://github.com/cli/cli',
+      },
+      {
+        input: 'http://gitee.com/dotnetchina/MiniWord',
+        result: 'https://gitee.com/dotnetchina/MiniWord',
+      },
+      { input: '', result: '' },
+      { input: undefined, result: '' },
+    ];
+
+    testCases.map((item) => {
+      expect(fillHttps(item.input)).toEqual(item.result);
     });
   });
 });

--- a/apps/web/src/common/utils/url.ts
+++ b/apps/web/src/common/utils/url.ts
@@ -64,8 +64,8 @@ export function getProvider(url: string) {
 export function fillHttps(url?: string): string {
   if (!url) return '';
   const trimmedUrl = url.endsWith('/') ? url.slice(0, -1) : url;
-  if (trimmedUrl.indexOf('https') === -1) {
-    return `https://${trimmedUrl}`;
+  if (!trimmedUrl.startsWith('https://')) {
+    return `https://${trimmedUrl.replace(/^http:\/\//, '')}`;
   }
   return trimmedUrl;
 }


### PR DESCRIPTION
## Problem

`fillHttps` decided whether to prefix `https://` by checking `trimmedUrl.indexOf('https') === -1`, i.e. it looked for the substring `https` **anywhere** in the input. An input that starts with `http://` (and does not happen to contain `https` later in the string) therefore fell into the prefixing branch:

```js
fillHttps('http://github.com/cli/cli')
// => 'https://http://github.com/cli/cli'
```

This value is what the submit-project forms send to the backend as the repo url:

- `FormSingleRepo` — the "manually enter repository url" input (`onSubmit`: `[data.url, selectVal].map(fillHttps)`)
- `FormCommunity` — the software artifact repository and governance repository inputs (`v.map(fillHttps)`)
- `AssessmentSection` (os-selection) — `fillHttps(description.trim())`

A user who pastes a plain-`http` repo address gets a task created for a URL that cannot be resolved.

## Fix

Prefix `https://` only when the input does not already start with the scheme, and strip a leading `http://` first so plain-http inputs are normalized to their https equivalent (the hubs used by the platform all serve https):

```js
fillHttps('http://github.com/cli/cli')  // => 'https://github.com/cli/cli'
fillHttps('github.com/cli/cli')         // => 'https://github.com/cli/cli' (unchanged)
fillHttps('https://github.com/cli/cli') // => 'https://github.com/cli/cli' (unchanged)
```

## Verification

- fail-before: new `fillHttps` test case fails with `Expected: "https://github.com/cli/cli", Received: "https://http://github.com/cli/cli"`
- pass-after: full suite `17 suites / 70 tests` pass (`npx jest` in `apps/web`)
- eslint / prettier clean on changed files (repo lint-staged hooks pass)

## Note

Generated with the help of an AI coding agent; the bug finding, fix design and verification were reviewed and validated as described above.