### PR TITLE
fix: getDeveloperLink maps gitcode.com profiles to the atomgit platform

### DIFF
--- a/apps/web/src/common/utils/links.test.ts
+++ b/apps/web/src/common/utils/links.test.ts
@@ -5,6 +5,7 @@ import {
   compareIdsSplit,
   getShortAnalyzeLink,
   getShortCompareLink,
+  getDeveloperLink,
 } from './links';
 
 describe('links', () => {
@@ -37,6 +38,21 @@ describe('links', () => {
   it('getShortCompareLink', () => {
     expect(getShortCompareLink(['S35IC7P4', 'S35ICXD4'])).toBe(
       '/compare/S35IC7P4..S35ICXD4'
+    );
+  });
+
+  it('getDeveloperLink', () => {
+    expect(getDeveloperLink('https://github.com/EdmondFrank')).toBe(
+      '/developer/github/EdmondFrank'
+    );
+    expect(getDeveloperLink('https://gitee.com/dotnetchina')).toBe(
+      '/developer/gitee/dotnetchina'
+    );
+    expect(getDeveloperLink('https://gitcode.com/openharmony-sig')).toBe(
+      '/developer/gitcode/openharmony-sig'
+    );
+    expect(getDeveloperLink('https://atomgit.com/openharmony')).toBe(
+      '/developer/atomgit/openharmony'
     );
   });
 });

--- a/apps/web/src/common/utils/links.ts
+++ b/apps/web/src/common/utils/links.ts
@@ -74,7 +74,9 @@ export const getDeveloperLink = (url: string) => {
     ? 'gitee'
     : hostname.includes('github.com')
     ? 'github'
-    : hostname.includes('gitcode.com') || hostname.includes('atomgit.com')
+    : hostname.includes('gitcode.com')
+    ? 'gitcode'
+    : hostname.includes('atomgit.com')
     ? 'atomgit'
     : 'github';
   return `/developer/${platform}/${encodeURIComponent(user)}`;


### PR DESCRIPTION
## Problem

The hostname chain in `getDeveloperLink` (`apps/web/src/common/utils/links.ts`) folded `gitcode.com` and `atomgit.com` into the same branch:

```ts
hostname.includes('gitcode.com') || hostname.includes('atomgit.com')
  ? 'atomgit'
```

The home search dropdown builds developer profile links through this helper (`getDeveloperInfo` → `profileLink`), so a GitCode developer result linked to `/developer/atomgit/<user>` instead of `/developer/gitcode/<user>`.

The developer route accepts four platforms (`KNOWN_PLATFORMS = ['github', 'gitee', 'gitcode', 'atomgit']` in `pages/developer/[platform].tsx`), so the wrong link does not 404 — it silently renders the **wrong platform's** developer analysis page.

## Fix

Give `gitcode.com` its own branch in the chain:

```ts
hostname.includes('gitcode.com') ? 'gitcode' : ...
```

```js
getDeveloperLink('https://gitcode.com/openharmony-sig')
// before: '/developer/atomgit/openharmony-sig'
// after:  '/developer/gitcode/openharmony-sig'
```

## Verification

- fail-before: new `getDeveloperLink` test fails with `Expected: "/developer/gitcode/openharmony-sig", Received: "/developer/atomgit/openharmony-sig"`
- pass-after: full suite `17 suites / 70 tests` pass (`npx jest` in `apps/web`)
- lint-staged (prettier + eslint) pass
- dedup: no open PR or issue mentions `getDeveloperLink` / a gitcode platform mapping

## Note

Generated with the help of an AI coding agent; the bug finding, fix design and verification were reviewed and validated as described above.