### PR TITLE
fix: crash on URL hashes containing a malformed percent sequence

### DIFF
--- a/apps/web/src/common/hooks/useHashchangeEvent.test.tsx
+++ b/apps/web/src/common/hooks/useHashchangeEvent.test.tsx
@@ -1,0 +1,58 @@
+import { renderHook, act, waitFor, screen } from '@testing-library/react';
+import useHashchangeEvent from './useHashchangeEvent';
+
+describe('useHashchangeEvent', () => {
+  afterEach(() => {
+    window.location.hash = '';
+  });
+
+  it('returns the initial hash without the query string', () => {
+    window.location.hash = '#organizations_activity_overview?tab=1';
+    const { result } = renderHook(() => useHashchangeEvent());
+    expect(result.current).toBe('organizations_activity_overview');
+  });
+
+  it('tracks hashchange events', async () => {
+    window.location.hash = '';
+    const { result } = renderHook(() => useHashchangeEvent());
+    expect(result.current).toBe('');
+
+    act(() => {
+      window.location.hash = '#contribution_last';
+    });
+    await waitFor(() => expect(result.current).toBe('contribution_last'));
+  });
+
+  it('does not throw when the hash contains a malformed percent sequence', () => {
+    window.location.hash = '#contributors%';
+    jest.useFakeTimers();
+    try {
+      const { result } = renderHook(() => useHashchangeEvent());
+      expect(result.current).toBe('contributors%');
+      act(() => {
+        jest.advanceTimersByTime(200);
+      });
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('highlights the matching card after the debounce', () => {
+    document.body.innerHTML =
+      '<div id="organizations_activity_overview" class="base-card" data-testid="hash-card"></div>';
+    window.location.hash = '#organizations_activity_overview';
+    jest.useFakeTimers();
+    try {
+      renderHook(() => useHashchangeEvent());
+      act(() => {
+        jest.advanceTimersByTime(200);
+      });
+      expect(screen.getByTestId('hash-card')).toHaveClass(
+        'card-hash-active-border'
+      );
+    } finally {
+      jest.useRealTimers();
+      document.body.innerHTML = '';
+    }
+  });
+});

--- a/apps/web/src/common/hooks/useHashchangeEvent.ts
+++ b/apps/web/src/common/hooks/useHashchangeEvent.ts
@@ -21,7 +21,6 @@ const useHashchangeEvent = (
         let parts = hash.split('?');
         hash = parts[0];
       }
-      console.log('hashChangeHandle', hash);
 
       const id = hash.replace('#', '');
       setActiveId(id);
@@ -35,9 +34,13 @@ const useHashchangeEvent = (
 
   useDebounce(
     () => {
-      console.log(activeId);
       if (!activeId) return;
-      const decodedId = decodeURIComponent(activeId);
+      let decodedId = activeId;
+      try {
+        decodedId = decodeURIComponent(activeId);
+      } catch (e) {
+        // hash may contain a malformed percent sequence; use it as-is
+      }
       const el = document.getElementById(decodedId);
       if (!el) return;
       const cards = document.querySelectorAll(`.${cardClassName}`);


### PR DESCRIPTION
## Problem

`useHashchangeEvent` (`apps/web/src/common/hooks/useHashchangeEvent.ts`) decodes the current hash with a bare `decodeURIComponent()` before looking up the element to highlight:

```ts
const decodedId = decodeURIComponent(activeId);
```

A hash like `#contributors%` — a truncated or hand-edited anchor, e.g. a copied link whose percent-escape was cut in half — makes `decodeURIComponent` throw `URIError: URI malformed` inside the debounced effect, which takes down the page section rendered around the hook. The hook is used by the sidebars / data views of the analyze, dataHub, lab, system-admin, oh and os-situation pages.

## Fix

Fall back to the raw hash when decoding fails:

```ts
let decodedId = activeId;
try {
  decodedId = decodeURIComponent(activeId);
} catch (e) {
  // hash may contain a malformed percent sequence; use it as-is
}
```

Also drops two leftover `console.log` debug statements in the same hook (they fired on every hash change / debounce tick in production).

## Verification

- fail-before: new hook test fails with `URIError: URI malformed` for hash `#contributors%`
- pass-after: hook test `4/4` pass; full suite `18 suites / 73 tests` pass (`npx jest` in `apps/web`)
- lint-staged (prettier + eslint incl. `testing-library/no-node-access`) pass
- dedup: no open PR or issue mentions `useHashchangeEvent` / hash decoding

## Note

Generated with the help of an AI coding agent; the bug finding, fix design and verification were reviewed and validated as described above.