### PR TITLE
fix: overview line chart crashes on partial metric responses

### DIFF
--- a/apps/web/src/common/transform/transDataForOverview.test.ts
+++ b/apps/web/src/common/transform/transDataForOverview.test.ts
@@ -33,4 +33,35 @@ describe('transDataForOverview', () => {
     // console.log(JSON.stringify(result, null, 2));
     expect(result).toEqual(overviewOutputData);
   });
+
+  it('tolerates a metric type missing from the data (partial response)', () => {
+    const partialData = {
+      metricActivity: (overviewData.data as any).metricActivity,
+    };
+
+    const result = transDataForOverview(partialData, opts, dateKey);
+
+    const activity = result.yAxisResult.find((r) => r.name === 'activityScore');
+    const codeQuality = result.yAxisResult.find(
+      (r) => r.name === 'codeQualityGuarantee'
+    );
+    expect(activity.data.length).toBe(result.xAxis.length);
+    expect(activity.data.some((v) => v !== null)).toBe(true);
+    expect(codeQuality.data.every((v) => v === null)).toBe(true);
+  });
+
+  it('tolerates a metric type that is null in the data (partial response)', () => {
+    const partialData = {
+      ...(overviewData.data as any),
+      metricCommunity: null,
+    };
+
+    const result = transDataForOverview(partialData, opts, dateKey);
+
+    const community = result.yAxisResult.find(
+      (r) => r.name === 'communitySupportScore'
+    );
+    expect(community.data.every((v) => v === null)).toBe(true);
+    expect(result.xAxis.length).toBeGreaterThan(0);
+  });
 });

--- a/apps/web/src/common/transform/transDataForOverview.ts
+++ b/apps/web/src/common/transform/transDataForOverview.ts
@@ -11,7 +11,7 @@ const filterDataByCommunityRepoType = (
 ) => {
   const result: any = {};
   Object.keys(data).forEach((key: any) => {
-    result[key] = data[key].filter((item: any) => {
+    result[key] = (data[key] || []).filter((item: any) => {
       // if type not exist then return true
       if (!item.type) return true;
       return item.type === communityRepoType;
@@ -42,7 +42,7 @@ export function transDataForOverview(
   const metricObj: any = {};
   for (let i = 0; i < maxLen; i++) {
     opts.forEach(({ type, key }) => {
-      const item = filteredData[type][i];
+      const item = filteredData[type]?.[i];
       if (item) {
         const time = item[timeKey];
         set(metricObj, [time, [key]], item[key]);


### PR DESCRIPTION
## Problem

`transDataForOverview` (`apps/web/src/common/transform/transDataForOverview.ts`) walks every metric type listed in `opts`, but `filterDataByCommunityRepoType` only copies the keys that exist in the query result and dereferenced `data[key]` without a null guard:

- **a metric field absent from the response** crashed the transform loop with

  ```
  TypeError: Cannot read properties of undefined (reading '0')
  ```

  whenever any other metric in `opts` had data. The length lookup at the top of the function is already guarded (`filteredData[type]?.length`) but the element access in the loop was not.

- **a metric field that came back `null`** crashed the pre-filter with

  ```
  TypeError: Cannot read properties of null (reading 'filter')
  ```

Both shapes occur with partial GraphQL responses. The transform feeds the overview line charts of the analyze and contributor pages (`OverviewSummary/LineChart.tsx`, `Contributor/OverviewSummary/LineChart.tsx`), so one incomplete metric field takes the whole chart card down.

## Fix

Treat absent/null metric fields like an empty series — the remaining metrics still render and the missing one yields `null` points:

```ts
result[key] = (data[key] || []).filter(...);   // null field
const item = filteredData[type]?.[i];          // absent field
```

## Verification

- fail-before: the two new test cases fail with the exact TypeErrors above
- pass-after: full suite `17 suites / 71 tests` pass (`npx jest` in `apps/web`)
- lint-staged (prettier + eslint) pass
- dedup: no open PR or issue mentions `transDataForOverview`

## Note

Generated with the help of an AI coding agent; the bug finding, fix design and verification were reviewed and validated as described above.