### PR TITLE
fix: language overview silently drops entries when merging into Others

### DIFF
--- a/apps/web/src/modules/developer/DataView/OverviewSummary/Languages/Languages.test.tsx
+++ b/apps/web/src/modules/developer/DataView/OverviewSummary/Languages/Languages.test.tsx
@@ -1,0 +1,76 @@
+import { processLanguages } from './Languages';
+
+const makeLanguage = (
+  name: string,
+  ratio: number,
+  contribution = 0
+): { language: string; ratio: number; contribution: number } => ({
+  language: name,
+  ratio,
+  contribution,
+});
+
+describe('processLanguages', () => {
+  it('keeps every language when there are 10 or fewer', () => {
+    const data = Array.from({ length: 7 }, (_, i) =>
+      makeLanguage(`lang${i + 1}`, i + 1)
+    );
+
+    const result = processLanguages(data);
+
+    expect(result.map((l) => l.name)).toEqual([
+      'lang1',
+      'lang2',
+      'lang3',
+      'lang4',
+      'lang5',
+      'lang6',
+      'lang7',
+    ]);
+  });
+
+  it('merges entries beyond the first 10 into Others without dropping any', () => {
+    const data = Array.from({ length: 12 }, (_, i) =>
+      makeLanguage(`lang${i + 1}`, i + 1)
+    );
+
+    const result = processLanguages(data);
+
+    expect(result).toHaveLength(11);
+    expect(result.slice(0, 10).map((l) => l.name)).toEqual(
+      Array.from({ length: 10 }, (_, i) => `lang${i + 1}`)
+    );
+    expect(result[10]).toEqual({
+      name: 'Others',
+      percentage: 23,
+      contribution: 0,
+    });
+  });
+
+  it('preserves the total percentage', () => {
+    const data = Array.from({ length: 12 }, (_, i) =>
+      makeLanguage(`lang${i + 1}`, i + 1)
+    );
+    const total = data.reduce((sum, l) => sum + l.ratio, 0);
+
+    const result = processLanguages(data);
+
+    expect(result.reduce((sum, l) => sum + l.percentage, 0)).toEqual(total);
+  });
+
+  it('filters out zero-ratio languages', () => {
+    const data = [
+      makeLanguage('go', 40),
+      makeLanguage('cobol', 0),
+      makeLanguage('rust', 60),
+    ];
+
+    const result = processLanguages(data);
+
+    expect(result.map((l) => l.name)).toEqual(['go', 'rust']);
+  });
+
+  it('returns an empty list for missing data', () => {
+    expect(processLanguages(undefined)).toEqual([]);
+  });
+});

--- a/apps/web/src/modules/developer/DataView/OverviewSummary/Languages/Languages.tsx
+++ b/apps/web/src/modules/developer/DataView/OverviewSummary/Languages/Languages.tsx
@@ -13,10 +13,9 @@ interface LanguagesProps {
   data?: LanguageData[];
 }
 
-const Languages: React.FC<LanguagesProps> = ({ data }) => {
-  const { t } = useTranslation();
-
-  // 如果没有数据或数据为空，使用默认值
+export const processLanguages = (
+  data?: LanguageData[]
+): { name: string; percentage: number; contribution: number }[] => {
   const languages =
     data && data.length > 0
       ? data
@@ -29,21 +28,26 @@ const Languages: React.FC<LanguagesProps> = ({ data }) => {
       : [];
 
   // 如果有超过 10 种语言，将剩余的合并为"Others"
-  const processedLanguages =
-    languages.length > 6
-      ? [
-          ...languages.slice(0, 6),
-          {
-            name: 'Others',
-            percentage: languages
-              .slice(9)
-              .reduce((sum, lang) => sum + lang.percentage, 0),
-            contribution: languages
-              .slice(9)
-              .reduce((sum, lang) => sum + (lang.contribution || 0), 0),
-          },
-        ]
-      : languages;
+  return languages.length > 10
+    ? [
+        ...languages.slice(0, 10),
+        {
+          name: 'Others',
+          percentage: languages
+            .slice(10)
+            .reduce((sum, lang) => sum + lang.percentage, 0),
+          contribution: languages
+            .slice(10)
+            .reduce((sum, lang) => sum + (lang.contribution || 0), 0),
+        },
+      ]
+    : languages;
+};
+
+const Languages: React.FC<LanguagesProps> = ({ data }) => {
+  const { t } = useTranslation();
+
+  const processedLanguages = processLanguages(data);
 
   const colorList = [
     '#4791ff',
@@ -63,7 +67,7 @@ const Languages: React.FC<LanguagesProps> = ({ data }) => {
     <div className="relative flex h-full max-w-[870px] scroll-mt-[200px] flex-col items-center justify-center gap-6 p-4">
       <div
         data-html2canvas-ignore="true"
-        className="absolute  right-7 -top-9 z-50 flex items-center justify-end gap-2"
+        className="absolute  -top-9 right-7 z-50 flex items-center justify-end gap-2"
       >
         <Tooltip
           placement="top"


### PR DESCRIPTION
## Motivation

On the developer overview page, the **contributor languages** bar shows wrong data whenever a contributor uses 7 or more languages. The merge logic mixed three different numbers:

```js
const processedLanguages =
  languages.length > 6                     // threshold: 7+ languages
    ? [
        ...languages.slice(0, 6),          // keep the first 6
        {
          name: 'Others',
          percentage: languages
            .slice(9)                      // but fold in only from index 9
            .reduce((sum, lang) => sum + lang.percentage, 0),
          ...
        },
      ]
    : languages;
```

The entries at **indices 6, 7 and 8 are neither displayed nor folded into Others** — they are silently dropped:

- The bar segments sum to less than 100% (the bar is the percentage of each language).
- With exactly 7-9 languages, `slice(9)` is empty, so the legend renders a meaningless `Others 0.00%` row.

The comment above the code says "如果有超过 10 种语言，将剩余的合并为'Others'" (merge the rest into Others when there are more than 10 languages), and the `colorList` right below has exactly 11 entries — 10 languages plus Others.

## Change

Merge only when there are more than 10 languages, keep the first 10, and fold everything from index 10 into Others, so every language is either shown or merged:

```js
return languages.length > 10
  ? [
      ...languages.slice(0, 10),
      { name: 'Others', percentage: languages.slice(10).reduce(...), ... },
    ]
  : languages;
```

The aggregation is extracted into an exported `processLanguages` helper (same behavior for the filter/empty-data handling) so it can be unit tested.

## Verification

```
$ yarn workspace @oss-compass/web test:ci -- Languages
# before the fix (helper extracted, original threshold/slices kept)
✕ keeps every language when there are 10 or fewer   # 7th language missing
✕ merges entries beyond the first 10 into Others without dropping any
✕ preserves the total percentage
✓ filters out zero-ratio languages
✓ returns an empty list for missing data
Tests: 3 failed, 2 passed, 5 total

# after the fix
Tests: 5 passed, 5 total
```

The new test covers: 7 languages are all kept (no Others row), 12 languages produce the first 10 plus an Others entry summing entries 11-12 (23), the total percentage is preserved, zero-ratio languages are still filtered, and missing data still yields an empty list. lint-staged (prettier + eslint) passes on the changed files.

DCO sign-off included.
