### PR TITLE
fix: contributor graph scale ignores the minimum, overflowing node sizes and link opacity

### DIFF
--- a/apps/web/src/modules/developer/DataView/utils.js
+++ b/apps/web/src/modules/developer/DataView/utils.js
@@ -24,7 +24,7 @@ const colorMap = {
 // 工具函数
 const calculateValues = (count, max, min, valueMax, valueMin) => {
   let diff = max - min;
-  let ratio = count / diff;
+  let ratio = (count - min) / diff;
   let valueRange = valueMax - valueMin;
   let value = valueMin + valueRange * ratio;
   return value;

--- a/apps/web/src/modules/developer/DataView/utils.test.js
+++ b/apps/web/src/modules/developer/DataView/utils.test.js
@@ -1,0 +1,52 @@
+import { calcData } from '@modules/developer/DataView/utils';
+
+const rawData = [
+  { repo: 'https://github.com/a/r1', total_contribution: 100 },
+  { repo: 'https://github.com/a/r2', total_contribution: 50 },
+  { repo: 'https://github.com/a/r3', total_contribution: 70 },
+];
+
+const getRepoNodes = (graph) => graph.nodes.filter((n) => n.type === 'repo');
+const byContribution = (a, b) => a.contributor_count - b.contributor_count;
+
+describe('calcData', () => {
+  it('keeps every node symbol size within the configured range', () => {
+    const graph = calcData(rawData, 'alice', 0, 'repo');
+
+    getRepoNodes(graph).forEach((n) => {
+      expect(n.symbolSize).toBeGreaterThanOrEqual(1);
+      expect(n.symbolSize).toBeLessThanOrEqual(70);
+    });
+  });
+
+  it('maps the smallest contribution to the minimum symbol size', () => {
+    const graph = calcData(rawData, 'alice', 0, 'repo');
+    const sorted = getRepoNodes(graph).sort(byContribution);
+
+    expect(sorted[0].symbolSize).toBeLessThan(5);
+  });
+
+  it('scales node sizes in the same order as the contributions', () => {
+    const graph = calcData(rawData, 'alice', 0, 'repo');
+    const sorted = getRepoNodes(graph).sort(byContribution);
+
+    expect(sorted[0].symbolSize).toBeLessThan(sorted[1].symbolSize);
+    expect(sorted[1].symbolSize).toBeLessThan(sorted[2].symbolSize);
+  });
+
+  it('keeps link opacity within [0.01, 0.99]', () => {
+    const graph = calcData(rawData, 'alice', 0, 'repo');
+
+    expect(graph.links).toHaveLength(3);
+    graph.links.forEach((l) => {
+      expect(l.lineStyle.opacity).toBeGreaterThanOrEqual(0.01);
+      expect(l.lineStyle.opacity).toBeLessThanOrEqual(0.99);
+    });
+  });
+
+  it('excludes repos below the contribution limit', () => {
+    const graph = calcData(rawData, 'alice', 60, 'repo');
+
+    expect(getRepoNodes(graph).map((n) => n.id)).toEqual(['a/r1', 'a/r3']);
+  });
+});


### PR DESCRIPTION
## Motivation

The contributor-repo relation graph (`RepoGraph` / `ReopleGraph` on the developer data view) draws node sizes and link opacities on a wrong scale. `calculateValues` in `apps/web/src/modules/developer/DataView/utils.js` is meant to map a contribution count from `[min, max]` onto `[valueMin, valueMax]`:

```js
const calculateValues = (count, max, min, valueMax, valueMin) => {
  let diff = max - min;
  let ratio = count / diff;               // min offset missing
  let valueRange = valueMax - valueMin;
  let value = valueMin + valueRange * ratio;
  return value;
};
```

The `- min` offset is missing, so the mapping is not the intended linear rescale. Concretely, with node sizes meant to span `[1, 70]`:

- the repo with the **smallest** contribution is drawn at almost the maximum size,
- the repo with the **largest** contribution exceeds the maximum (e.g. counts 50/70/100 with min=50 produce sizes 68.6 / 95.6 / **136.3**),
- link line opacities, meant to span `[0.01, 0.99]`, go up to ~1.9.

Because every value is shifted by the same wrong offset, small and large contributions end up looking nearly the same size, which defeats the purpose of the size encoding.

## Change

Subtract `min` before dividing by the range:

```js
let ratio = (count - min) / diff;
```

Counts cannot exceed `max` (`getMaxMin` already adds 1 to the maximum), so mapped values now stay within `[valueMin, valueMax)`.

## Verification

```
$ yarn workspace @oss-compass/web test:ci -- utils.test
# before the fix
✕ keeps every node symbol size within the configured range    # largest: 136.3 > 70
✕ maps the smallest contribution to the minimum symbol size   # smallest: 68.6 instead of 1
✓ scales node sizes in the same order as the contributions
✕ keeps link opacity within [0.01, 0.99]                      # largest: ~1.93
✓ excludes repos below the contribution limit
Tests: 3 failed, 2 passed, 5 total

# after the fix
Tests: 5 passed, 5 total
```

The new test covers: all repo node symbol sizes stay within `[1, 70]`, the smallest contribution maps to the minimum size, sizes keep the contributions' order, link opacities stay within `[0.01, 0.99]`, and the contribution-limit filter is unchanged. lint-staged (prettier + eslint) passes on the changed files.

DCO sign-off included.
