### PR TITLE
fix: radar chart axis max is never rounded up and is passed as a string

### DIFF
--- a/apps/web/src/modules/developer/DataView/OverviewSummary/Radar/Chart.test.tsx
+++ b/apps/web/src/modules/developer/DataView/OverviewSummary/Radar/Chart.test.tsx
@@ -1,0 +1,23 @@
+import { calcRadarAxisMax } from './Chart';
+
+describe('calcRadarAxisMax', () => {
+  it('rounds the maximum up to the next multiple of 10', () => {
+    expect(calcRadarAxisMax([17, 3, 5])).toBe(20);
+  });
+
+  it('keeps an exact multiple of 10', () => {
+    expect(calcRadarAxisMax([100, 4])).toBe(100);
+  });
+
+  it('gives a single small value the minimum headroom', () => {
+    expect(calcRadarAxisMax([1])).toBe(10);
+  });
+
+  it('rounds up across a multiple of 10', () => {
+    expect(calcRadarAxisMax([101, 4])).toBe(110);
+  });
+
+  it('returns a number, not a formatted string', () => {
+    expect(typeof calcRadarAxisMax([17, 3])).toBe('number');
+  });
+});

--- a/apps/web/src/modules/developer/DataView/OverviewSummary/Radar/Chart.tsx
+++ b/apps/web/src/modules/developer/DataView/OverviewSummary/Radar/Chart.tsx
@@ -15,6 +15,10 @@ interface ChartProps {
   data?: ContributionTypeData;
 }
 
+// 向上取整到最接近的10的倍数，给雷达图刻度留出余量
+export const calcRadarAxisMax = (values: number[]): number =>
+  Math.ceil(Math.max(...values) / 10) * 10;
+
 const Chart: React.FC<ChartProps> = ({ containerRef, data }) => {
   // 如果没有数据，使用默认值
   const contributionData = data;
@@ -30,8 +34,7 @@ const Chart: React.FC<ChartProps> = ({ containerRef, data }) => {
   ];
 
   // 计算最大值，用于设置雷达图的刻度
-  const maxValue = Math.max(...radarData);
-  const roundedMaxValue = ((maxValue / 10) * 10).toFixed(2); // 向上取整到最接近的10的倍数
+  const roundedMaxValue = calcRadarAxisMax(radarData);
 
   const option = {
     grid: {


### PR DESCRIPTION
## Motivation

The **contribution type radar** on the developer overview page computes its axis maximum with a no-op expression:

```js
// 计算最大值，用于设置雷达图的刻度
const maxValue = Math.max(...radarData);
const roundedMaxValue = ((maxValue / 10) * 10).toFixed(2); // 向上取整到最接近的10的倍数
```

Two problems in that line:

1. `(maxValue / 10) * 10` divides by 10 and multiplies it straight back — it is an identity operation on the value, not the "round up to the nearest multiple of 10" the comment describes. The axis maximum equals the largest data point, so the polygon always touches the outer ring on the strongest axis with no headroom.
2. `.toFixed(2)` returns a **string** (`"17.00"`), which is assigned to every radar indicator's `max` — a numeric option that ECharts expects as a number.

## Change

```js
export const calcRadarAxisMax = (values: number[]): number =>
  Math.ceil(Math.max(...values) / 10) * 10;
```

Round the maximum up to the next multiple of 10 (an exact multiple stays as-is) and keep it a number. The computation is extracted into an exported helper so it can be unit tested; the component behavior is otherwise unchanged.

## Verification

```
$ yarn workspace @oss-compass/web test:ci -- Radar/Chart.test
# with the original expression kept in the extracted helper
✕ rounds the maximum up to the next multiple of 10     # 17 instead of 20
✕ keeps an exact multiple of 10                        # "100.00" instead of 100
✕ gives a single small value the minimum headroom      # 1 instead of 10
✕ rounds up across a multiple of 10                    # 101 instead of 110
✕ returns a number, not a formatted string             # typeof "17.00" is string
Tests: 5 failed, 5 total

# after the fix
Tests: 5 passed, 5 total
```

lint-staged (prettier + eslint) passes on the changed files.

DCO sign-off included.
