### PR TITLE
fix: preserve zero completion ratios in insight summaries

### DIFF
--- a/apps/web/src/modules/analyze/DataView/MetricDetail/MetricDashboard.test.tsx
+++ b/apps/web/src/modules/analyze/DataView/MetricDetail/MetricDashboard.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { useMetricDashboardQuery } from '@oss-compass/graphql';
+import MetricDashboard from './MetricDashboard';
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    query: { slugs: ['github.com', 'oss-compass', 'compass-web'] },
+  }),
+}));
+
+jest.mock('@modules/analyze/hooks/useCompareItems', () => ({
+  __esModule: true,
+  default: () => ({
+    compareItems: [
+      { label: 'https://github.com/oss-compass/compass-web', level: 'repo' },
+    ],
+  }),
+}));
+
+jest.mock('@modules/analyze/hooks/useQueryDateRange', () => ({
+  __esModule: true,
+  default: () => ({ timeStart: '2026-01-01', timeEnd: '2026-02-01' }),
+}));
+
+jest.mock('@oss-compass/graphql', () => ({
+  useMetricDashboardQuery: jest.fn(),
+}));
+
+jest.mock('@common/gqlClient', () => ({ __esModule: true, default: {} }));
+jest.mock('@common/utils', () => jest.requireActual('@common/utils/number'));
+
+const mockUseMetricDashboardQuery = useMetricDashboardQuery as jest.Mock;
+
+describe.each([
+  [
+    'Issue',
+    'issuesDetailOverview',
+    'issueCompletionRatio',
+    'issueCompletionCount',
+  ],
+  ['PR', 'pullsDetailOverview', 'pullCompletionRatio', 'pullCompletionCount'],
+])('%s completion rate', (_name, overview, ratioField, countField) => {
+  it.each([
+    { ratio: 0, count: 0, expected: '0% (0)' },
+    { ratio: 0, count: null, expected: '0% (0)' },
+    { ratio: 0, count: undefined, expected: '0% (0)' },
+    { ratio: 0.25, count: 3, expected: '25% (3)' },
+    { ratio: 1, count: 12, expected: '100% (12)' },
+    { ratio: 1 / 3, count: 4, expected: '33.3% (4)' },
+    { ratio: null, count: 0, expected: '/' },
+    { ratio: undefined, count: 0, expected: '/' },
+  ])(
+    'renders $expected for ratio $ratio and count $count',
+    ({ ratio, count, expected }) => {
+      mockUseMetricDashboardQuery.mockReturnValue({
+        isLoading: false,
+        data: { [overview]: { [ratioField]: ratio, [countField]: count } },
+      });
+
+      render(<MetricDashboard />);
+
+      expect(screen.getByText(expected)).toBeInTheDocument();
+    }
+  );
+});

--- a/apps/web/src/modules/analyze/DataView/MetricDetail/MetricDashboard.tsx
+++ b/apps/web/src/modules/analyze/DataView/MetricDetail/MetricDashboard.tsx
@@ -48,12 +48,12 @@ const Main = () => {
   if (isLoading) {
     return (
       <>
-        <div className="mt-6 mb-2 flex justify-between">
+        <div className="mb-2 mt-6 flex justify-between">
           <div className="text-xl font-semibold text-[#000000]">
             {t('analyze:metric_detail:project_deep_dive_insight')}
           </div>
           <div
-            className="flex cursor-pointer items-center gap-2 rounded border border-[#3A5BEF] py-1.5 px-3 text-xs text-[#3A5BEF]"
+            className="flex cursor-pointer items-center gap-2 rounded border border-[#3A5BEF] px-3 py-1.5 text-xs text-[#3A5BEF]"
             onClick={() => {
               const query = window.location.search;
               router.push('/analyze/insight/' + slugs + query);
@@ -69,12 +69,12 @@ const Main = () => {
   }
   return (
     <div>
-      <div className="mt-6 mb-2 flex justify-between">
+      <div className="mb-2 mt-6 flex justify-between">
         <div className="text-xl font-semibold text-[#000000]">
           {t('analyze:metric_detail:project_deep_dive_insight')}
         </div>
         <div
-          className="flex cursor-pointer items-center gap-2 rounded border border-[#3A5BEF] py-1.5 px-3 text-xs text-[#3A5BEF]"
+          className="flex cursor-pointer items-center gap-2 rounded border border-[#3A5BEF] px-3 py-1.5 text-xs text-[#3A5BEF]"
           onClick={() => {
             const query = window.location.search;
             router.push('/analyze/insight/' + slugs + query);
@@ -108,10 +108,10 @@ const MetricBoxContributors: React.FC<{
             {t('analyze:metric_detail:contributor')}
           </div>
         </div>
-        <div className="mt-4 mb-2 grid grid-cols-4 gap-4 pl-12">
+        <div className="mb-2 mt-4 grid grid-cols-4 gap-4 pl-12">
           <div>
             <div className="flex text-xl font-medium">
-              <div className="mt-1 mr-2 text-[#ccc]">
+              <div className="mr-2 mt-1 text-[#ccc]">
                 <IoPersonCircle />
               </div>
               <div className="line-clamp-1">-</div>
@@ -122,7 +122,7 @@ const MetricBoxContributors: React.FC<{
           </div>
           <div>
             <div className="flex text-xl font-medium">
-              <div className="mt-1 mr-2 text-[#ccc]">
+              <div className="mr-2 mt-1 text-[#ccc]">
                 <IoPersonCircle />
               </div>
               <div className="line-clamp-1">-</div>
@@ -133,7 +133,7 @@ const MetricBoxContributors: React.FC<{
           </div>
           <div>
             <div className="flex text-xl font-medium">
-              <div className="mt-1 mr-2 text-[#ccc]">
+              <div className="mr-2 mt-1 text-[#ccc]">
                 <IoPeopleCircle />
               </div>
               <div className="line-clamp-1">-</div>
@@ -144,7 +144,7 @@ const MetricBoxContributors: React.FC<{
           </div>
           <div>
             <div className="flex text-xl font-medium">
-              <div className="mt-1 mr-2 text-[#ccc]">
+              <div className="mr-2 mt-1 text-[#ccc]">
                 <IoPeopleCircle />
               </div>
               <div className="line-clamp-1">-</div>
@@ -165,10 +165,10 @@ const MetricBoxContributors: React.FC<{
           {t('analyze:metric_detail:contributor')}
         </div>
       </div>
-      <div className="mt-4 mb-2 grid grid-cols-4 gap-4 pl-12">
+      <div className="mb-2 mt-4 grid grid-cols-4 gap-4 pl-12">
         <div>
           <div className="flex text-xl font-medium">
-            <div className="mt-1 mr-2 text-[#ccc]">
+            <div className="mr-2 mt-1 text-[#ccc]">
               <IoPersonCircle />
             </div>
             <div className="line-clamp-1">{data.contributorAllCount || 0}</div>
@@ -190,7 +190,7 @@ const MetricBoxContributors: React.FC<{
         </div>
         <div>
           <div className="flex text-xl font-medium">
-            <div className="mt-1 mr-2 text-[#ccc]">
+            <div className="mr-2 mt-1 text-[#ccc]">
               <IoPeopleCircle />
             </div>
             <div className="line-clamp-1">{data.orgAllCount || 0}</div>
@@ -201,7 +201,7 @@ const MetricBoxContributors: React.FC<{
         </div>
         <div>
           <div className="flex text-xl font-medium">
-            <div className="mt-1 mr-2 text-[#ccc]">
+            <div className="mr-2 mt-1 text-[#ccc]">
               {getIcons(data.highestContributionOrganization?.origin)}
             </div>
             <div className="line-clamp-1">
@@ -229,10 +229,10 @@ const MetricBoxIssues: React.FC<{
             {t('analyze:metric_detail:issues')}
           </div>
         </div>
-        <div className="mt-4 mb-2 grid grid-cols-2 gap-4 pl-12">
+        <div className="mb-2 mt-4 grid grid-cols-2 gap-4 pl-12">
           <div>
             <div className="flex text-xl font-medium">
-              <div className="mt-1 mr-2 text-[#ccc]">
+              <div className="mr-2 mt-1 text-[#ccc]">
                 <GoIssueOpened />
               </div>
               <div className="line-clamp-1">-</div>
@@ -243,7 +243,7 @@ const MetricBoxIssues: React.FC<{
           </div>
           <div>
             <div className="flex text-xl font-medium">
-              <div className="mt-1 mr-2 text-[#ccc]">
+              <div className="mr-2 mt-1 text-[#ccc]">
                 <AiOutlineIssuesClose />
               </div>
               <div className="line-clamp-1">-</div>
@@ -254,7 +254,7 @@ const MetricBoxIssues: React.FC<{
           </div>
           <div>
             <div className="flex text-xl font-medium">
-              <div className="mt-1 mr-2 text-[#ccc]">
+              <div className="mr-2 mt-1 text-[#ccc]">
                 <AiFillClockCircle />
               </div>
               <div className="line-clamp-1">-</div>
@@ -265,7 +265,7 @@ const MetricBoxIssues: React.FC<{
           </div>
           <div>
             <div className="flex text-xl font-medium">
-              <div className="mt-1 mr-2 text-[#ccc]">
+              <div className="mr-2 mt-1 text-[#ccc]">
                 <BiChat />
               </div>
               <div className="line-clamp-1">-</div>
@@ -286,10 +286,10 @@ const MetricBoxIssues: React.FC<{
           {t('analyze:metric_detail:issues')}
         </div>
       </div>
-      <div className="mt-4 mb-2 grid grid-cols-2 gap-4 pl-12">
+      <div className="mb-2 mt-4 grid grid-cols-2 gap-4 pl-12">
         <div>
           <div className="flex text-xl font-medium">
-            <div className="mt-1 mr-2 text-[#ccc]">
+            <div className="mr-2 mt-1 text-[#ccc]">
               <GoIssueOpened />
             </div>
             <div className="line-clamp-1">{data.issueCount || 0}</div>
@@ -300,11 +300,11 @@ const MetricBoxIssues: React.FC<{
         </div>
         <div>
           <div className="flex text-xl font-medium">
-            <div className="mt-1 mr-2 text-[#ccc]">
+            <div className="mr-2 mt-1 text-[#ccc]">
               <AiOutlineIssuesClose />
             </div>
             <div className="line-clamp-1">
-              {data.issueCompletionRatio
+              {data.issueCompletionRatio != null
                 ? toFixed(data.issueCompletionRatio * 100, 1) +
                   '% (' +
                   (data.issueCompletionCount || 0) +
@@ -318,7 +318,7 @@ const MetricBoxIssues: React.FC<{
         </div>
         <div>
           <div className="flex text-xl font-medium">
-            <div className="mt-1 mr-2 text-[#ccc]">
+            <div className="mr-2 mt-1 text-[#ccc]">
               <AiFillClockCircle />
             </div>
             <div className="line-clamp-1">
@@ -331,7 +331,7 @@ const MetricBoxIssues: React.FC<{
         </div>
         <div>
           <div className="flex text-xl font-medium">
-            <div className="mt-1 mr-2 text-[#ccc]">
+            <div className="mr-2 mt-1 text-[#ccc]">
               <BiChat />
             </div>
             <div className="line-clamp-1">
@@ -362,10 +362,10 @@ const MetricBoxPr: React.FC<{
             {t('analyze:metric_detail:pull_requests')}
           </div>
         </div>
-        <div className="mt-4 mb-2 grid grid-cols-2 gap-4 pl-12">
+        <div className="mb-2 mt-4 grid grid-cols-2 gap-4 pl-12">
           <div>
             <div className="flex text-xl font-medium">
-              <div className="line-clamp-1 mt-1 mr-2 text-[#ccc]">
+              <div className="mr-2 mt-1 line-clamp-1 text-[#ccc]">
                 <BiGitPullRequest />
               </div>
               <div className="line-clamp-1">-</div>
@@ -376,7 +376,7 @@ const MetricBoxPr: React.FC<{
           </div>
           <div>
             <div className="flex text-xl font-medium">
-              <div className="mt-1 mr-2 text-[#ccc]">
+              <div className="mr-2 mt-1 text-[#ccc]">
                 <GoGitPullRequestClosed />
               </div>
               <div className="line-clamp-1">-</div>
@@ -387,7 +387,7 @@ const MetricBoxPr: React.FC<{
           </div>
           <div>
             <div className="flex text-xl font-medium">
-              <div className="mt-1 mr-2 text-[#ccc]">
+              <div className="mr-2 mt-1 text-[#ccc]">
                 <AiFillClockCircle />
               </div>
               <div className="line-clamp-1">-</div>
@@ -398,7 +398,7 @@ const MetricBoxPr: React.FC<{
           </div>
           <div>
             <div className="flex text-xl font-medium">
-              <div className="mt-1 mr-2 text-[#ccc]">
+              <div className="mr-2 mt-1 text-[#ccc]">
                 <BiGitCommit />
               </div>
               <div className="line-clamp-1">-</div>
@@ -419,10 +419,10 @@ const MetricBoxPr: React.FC<{
           {t('analyze:metric_detail:pull_requests')}
         </div>
       </div>
-      <div className="mt-4 mb-2 grid grid-cols-2 gap-4 pl-12">
+      <div className="mb-2 mt-4 grid grid-cols-2 gap-4 pl-12">
         <div>
           <div className="flex text-xl font-medium">
-            <div className="line-clamp-1 mt-1 mr-2 text-[#ccc]">
+            <div className="mr-2 mt-1 line-clamp-1 text-[#ccc]">
               <BiGitPullRequest />
             </div>
             <div className="line-clamp-1">{data.pullCount || 0}</div>
@@ -433,11 +433,11 @@ const MetricBoxPr: React.FC<{
         </div>
         <div>
           <div className="flex text-xl font-medium">
-            <div className="mt-1 mr-2 text-[#ccc]">
+            <div className="mr-2 mt-1 text-[#ccc]">
               <GoGitPullRequestClosed />
             </div>
             <div className="line-clamp-1">
-              {data.pullCompletionRatio
+              {data.pullCompletionRatio != null
                 ? toFixed(data.pullCompletionRatio * 100, 1) +
                   '% (' +
                   (data.pullCompletionCount || 0) +
@@ -451,7 +451,7 @@ const MetricBoxPr: React.FC<{
         </div>
         <div>
           <div className="flex text-xl font-medium">
-            <div className="mt-1 mr-2 text-[#ccc]">
+            <div className="mr-2 mt-1 text-[#ccc]">
               <AiFillClockCircle />
             </div>
             <div className="line-clamp-1">
@@ -464,7 +464,7 @@ const MetricBoxPr: React.FC<{
         </div>
         <div>
           <div className="flex text-xl font-medium">
-            <div className="mt-1 mr-2 text-[#ccc]">
+            <div className="mr-2 mt-1 text-[#ccc]">
               <BiGitCommit />
             </div>
             <div className="line-clamp-1">{data.commitCount || 0}</div>
@@ -586,7 +586,7 @@ const getTopUser = (type, name) => {
 
   return (
     <>
-      <div className="mt-1 mr-2 text-[#ccc]">{userIcon}</div>
+      <div className="mr-2 mt-1 text-[#ccc]">{userIcon}</div>
       <div className="line-clamp-1">
         {url ? (
           <a


### PR DESCRIPTION
When the API reports a completion ratio of `0`, the insight dashboard currently displays `/` for both issues and pull requests. This makes a valid zero indistinguishable from missing data.

Use nullish checks so zero renders as `0% (0)`, while `null` and `undefined` still render as `/`. Preserve percentage rounding and the existing completion-count fallback. Add 16 component-rendering regression cases across both metrics. The other edits in `MetricDashboard.tsx` only reorder existing Tailwind classes as required by the repository's Prettier commit hook.

Related to #285's data-state semantics; this does not resolve its pending-analysis messaging requirement.

### Validation
- `yarn workspace @oss-compass/web test:ci --runInBand`: **25 suites / 118 tests passed**.
- Before the fix, the new suite reproduced **6 failing zero-value cases**; all 16 now pass.
- ESLint, Prettier, `git diff --check`, and the normal pre-commit hooks passed.
- Rendered the actual component with query/router/translation fixtures in Chrome via Playwright. Switched through zero, partial, rounded, complete, null and omitted ratios; desktop values were correct and there were no console errors.

### Limits
- The local production build was attempted but stopped because the sparse checkout omits `apps/web/public/data/collections—menus.json`. A full production build and backend-connected flow were not verified locally.
- The 390px fixture inspection shows existing text clipping from the component's multi-column layout. Responsive layout is unchanged by this PR.

