### PR TITLE
fix: distinguish analysis status from empty insight data

### DIFF
--- a/apps/web/src/modules/analyze/DataView/MetricDetail/MetricDashboard.test.tsx
+++ b/apps/web/src/modules/analyze/DataView/MetricDetail/MetricDashboard.test.tsx
@@ -1,0 +1,416 @@
+import React from 'react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import client from '@common/gqlClient';
+import useLabelStatus from '@modules/analyze/hooks/useLabelStatus';
+import { StatusContextProvider } from '@modules/analyze/context';
+import AnalysisStatus from '../Status/AnalysisStatus';
+import MetricDashboard from './MetricDashboard';
+
+let mockIds = ['a'];
+let mockStart = '2026-01-01';
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+jest.mock('next/router', () => ({
+  useRouter: () => ({ query: { slugs: mockIds, range: mockStart } }),
+}));
+jest.mock('@modules/analyze/hooks/useExtractShortIds', () => ({
+  __esModule: true,
+  default: () => ({ shortIds: mockIds }),
+}));
+jest.mock('@modules/analyze/hooks/useQueryDateRange', () => ({
+  __esModule: true,
+  default: () => ({ timeStart: mockStart, timeEnd: '2026-06-01' }),
+}));
+jest.mock('@common/gqlClient', () => ({
+  __esModule: true,
+  default: { request: jest.fn() },
+}));
+jest.mock('@common/utils', () => ({
+  ...jest.requireActual('@common/utils/number'),
+  getPathname: (label: string) => label,
+  compareIdsJoin: (ids: string[]) => ids.join('...'),
+}));
+
+const request = client.request as jest.Mock;
+const analysis = (status = 'success', id = 'a') => ({
+  analysisStatusVerify: {
+    label: `https://github.com/compass/${id}`,
+    level: 'repo',
+    shortCode: id,
+    collections: [],
+    status,
+  },
+});
+const zeroMetrics = {
+  contributorsDetailOverview: { contributorAllCount: 0, orgAllCount: 0 },
+  issuesDetailOverview: {
+    issueCount: 0,
+    issueCompletionCount: 0,
+    issueCompletionRatio: 0,
+    issueUnresponsiveCount: 0,
+    issueCommentFrequencyMean: 0,
+  },
+  pullsDetailOverview: {
+    pullCount: 0,
+    pullCompletionCount: 0,
+    pullCompletionRatio: 0,
+    pullUnresponsiveCount: 0,
+    commitCount: 0,
+  },
+};
+const pendingText =
+  'analyze:the_current_project_is_under_analysis_please_visit';
+const metricCalls = () =>
+  request.mock.calls.filter(([r]) =>
+    r.document.includes('query metricDashboard')
+  );
+const statusCalls = () =>
+  request.mock.calls.filter(([r]) => r.document.includes('query statusVerify'));
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+let queryClient: QueryClient;
+function Report({ statusOnly = false }) {
+  const status = useLabelStatus();
+  return (
+    <StatusContextProvider value={status}>
+      {statusOnly ? (
+        <AnalysisStatus>
+          <span>Ready</span>
+        </AnalysisStatus>
+      ) : (
+        <MetricDashboard />
+      )}
+    </StatusContextProvider>
+  );
+}
+function mount(statusOnly = false) {
+  const element = () => (
+    <QueryClientProvider client={queryClient}>
+      <Report statusOnly={statusOnly} />
+    </QueryClientProvider>
+  );
+  const view = render(element());
+  return { ...view, refresh: () => view.rerender(element()) };
+}
+function valueOf(name: string) {
+  return screen.getByText(`analyze:metric_detail:${name}`)
+    .previousElementSibling?.textContent;
+}
+beforeEach(() => {
+  mockIds = ['a'];
+  mockStart = '2026-01-01';
+  request.mockReset();
+  queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        keepPreviousData: true,
+        refetchOnWindowFocus: false,
+      },
+    },
+    logger: { log: console.log, warn: console.warn, error: () => {} },
+  });
+  request.mockImplementation(({ document, variables }) =>
+    Promise.resolve(
+      document.includes('query statusVerify')
+        ? analysis('success', variables.shortCode)
+        : zeroMetrics
+    )
+  );
+});
+afterEach(() => {
+  queryClient.clear();
+  jest.useRealTimers();
+});
+
+it('shows request loading before the task status is known without requesting metrics', () => {
+  request.mockReturnValue(new Promise(() => {}));
+  mount();
+  expect(
+    screen.getByRole('status', { name: 'common:loading' })
+  ).toHaveAttribute('aria-busy', 'true');
+  expect(metricCalls()).toHaveLength(0);
+});
+it.each(['pending', 'progress'])(
+  'shows %s as analysis in progress without requesting zero metrics',
+  async (status) => {
+    request.mockResolvedValue(analysis(status));
+    mount();
+    expect(await screen.findByText(pendingText)).toBeInTheDocument();
+    expect(screen.queryByText('0')).not.toBeInTheDocument();
+    expect(metricCalls()).toHaveLength(0);
+  }
+);
+it.each(['error', 'canceled', 'unknown'])(
+  'shows task status %s as retryable failure, not 404 or progress',
+  async (status) => {
+    request.mockResolvedValueOnce(analysis(status));
+    mount();
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'common:error.something_went_wrong'
+    );
+    expect(screen.queryByText(pendingText)).not.toBeInTheDocument();
+    expect(metricCalls()).toHaveLength(0);
+    fireEvent.click(
+      screen.getByRole('button', { name: 'common:error.try_again' })
+    );
+    await waitFor(() => expect(valueOf('contributor_count')).toBe('0'));
+  }
+);
+it('shows a failed status request as retryable failure instead of 404', async () => {
+  request.mockRejectedValueOnce(new Error('Network unavailable'));
+  mount();
+  await screen.findByRole('alert');
+  expect(screen.queryByText('common:error.url_404')).not.toBeInTheDocument();
+  fireEvent.click(
+    screen.getByRole('button', { name: 'common:error.try_again' })
+  );
+  await waitFor(() => expect(valueOf('contributor_count')).toBe('0'));
+});
+it('keeps an unsubmitted report distinct from a failed analysis', async () => {
+  request.mockResolvedValue(analysis('unsubmit'));
+  mount();
+  expect(await screen.findByText('common:error.url_404')).toBeInTheDocument();
+  expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  expect(metricCalls()).toHaveLength(0);
+});
+it('polls pending and progress until success, then stops polling', async () => {
+  jest.useFakeTimers();
+  request
+    .mockResolvedValueOnce(analysis('pending'))
+    .mockResolvedValueOnce(analysis('progress'));
+  mount();
+  await screen.findByText(pendingText);
+  await act(async () => {
+    jest.advanceTimersByTime(5000);
+  });
+  await waitFor(() => expect(statusCalls()).toHaveLength(2));
+  await act(async () => {
+    jest.advanceTimersByTime(5000);
+  });
+  await waitFor(() => expect(valueOf('contributor_count')).toBe('0'));
+  await act(async () => {
+    jest.advanceTimersByTime(15000);
+  });
+  expect(statusCalls()).toHaveLength(3);
+});
+it('stops polling when a pending task status request fails', async () => {
+  jest.useFakeTimers();
+  request
+    .mockResolvedValueOnce(analysis('pending'))
+    .mockRejectedValueOnce(new Error('Offline'));
+  mount();
+  await screen.findByText(pendingText);
+  await act(async () => {
+    jest.advanceTimersByTime(5000);
+  });
+  await screen.findByRole('alert');
+  await act(async () => {
+    jest.advanceTimersByTime(15000);
+  });
+  expect(statusCalls()).toHaveLength(2);
+});
+it('does not treat a partially verified comparison as ready', async () => {
+  mockIds = ['a', 'b'];
+  const later = deferred<ReturnType<typeof analysis>>();
+  request.mockImplementation(({ variables }) =>
+    variables.shortCode === 'a' ? Promise.resolve(analysis()) : later.promise
+  );
+  mount(true);
+  expect(
+    screen.getByRole('status', { name: 'common:loading' })
+  ).toBeInTheDocument();
+  await act(async () => later.resolve(analysis('progress', 'b')));
+  expect(await screen.findByText(pendingText)).toBeInTheDocument();
+  expect(screen.queryByText('Ready')).not.toBeInTheDocument();
+});
+it.each(['error', 'unsubmit'])(
+  'does not discard a comparison report with status %s',
+  async (status) => {
+    mockIds = ['a', 'b'];
+    request.mockImplementation(({ variables }) =>
+      Promise.resolve(
+        analysis(
+          variables.shortCode === 'a' ? 'success' : status,
+          variables.shortCode
+        )
+      )
+    );
+    mount(true);
+    await screen.findByText(
+      status === 'error'
+        ? 'common:error.something_went_wrong'
+        : 'common:error.url_404'
+    );
+    expect(screen.queryByText('Ready')).not.toBeInTheDocument();
+  }
+);
+it('separates metric request loading from task progress', async () => {
+  request
+    .mockResolvedValueOnce(analysis())
+    .mockReturnValue(new Promise(() => {}));
+  mount();
+  await waitFor(() => expect(metricCalls()).toHaveLength(1));
+  expect(
+    screen.getByRole('status', { name: 'common:loading' })
+  ).toBeInTheDocument();
+  expect(screen.queryByText(pendingText)).not.toBeInTheDocument();
+});
+it('retries a failed metric query without presenting empty data or zeroes', async () => {
+  request
+    .mockResolvedValueOnce(analysis())
+    .mockRejectedValueOnce(new Error('GraphQL error'));
+  mount();
+  await screen.findByRole('alert');
+  expect(screen.queryByText('common:no_data')).not.toBeInTheDocument();
+  expect(screen.queryByText('0')).not.toBeInTheDocument();
+  fireEvent.click(
+    screen.getByRole('button', { name: 'common:error.try_again' })
+  );
+  await waitFor(() => expect(valueOf('contributor_count')).toBe('0'));
+  expect(statusCalls()).toHaveLength(1);
+});
+it.each([
+  {},
+  {
+    contributorsDetailOverview: null,
+    issuesDetailOverview: null,
+    pullsDetailOverview: null,
+  },
+  {
+    contributorsDetailOverview: { contributorAllCount: null },
+    issuesDetailOverview: { issueCount: null },
+    pullsDetailOverview: { pullCount: null },
+  },
+])('shows successful empty data explicitly for %j', async (metrics) => {
+  request.mockResolvedValueOnce(analysis()).mockResolvedValueOnce(metrics);
+  mount();
+  expect(await screen.findByText('common:no_data')).toBeInTheDocument();
+  expect(screen.queryByText('0')).not.toBeInTheDocument();
+});
+it('preserves valid zero counts, averages and completion rates', async () => {
+  mount();
+  await screen.findByText('analyze:metric_detail:contributor_count');
+  for (const name of [
+    'contributor_count',
+    'org_count',
+    'newly_created_issues',
+    'unanswered_issue_count',
+    'average_comments_count',
+    'newly_created_pr_count',
+    'unanswered_pr_count',
+    'commit_count',
+  ]) {
+    expect(valueOf(name)).toBe('0');
+  }
+  expect(valueOf('issue_completion_rate')).toBe('0% (0)');
+  expect(valueOf('pr_completion_rate')).toBe('0% (0)');
+  expect(screen.queryByText('common:no_data')).not.toBeInTheDocument();
+});
+it.each([null, undefined])(
+  'keeps partial missing values (%s) distinct from zero',
+  async (missing) => {
+    request.mockResolvedValueOnce(analysis()).mockResolvedValueOnce({
+      contributorsDetailOverview: {
+        contributorAllCount: missing,
+        orgAllCount: 2,
+      },
+      issuesDetailOverview: {
+        issueCount: missing,
+        issueCompletionRatio: 0,
+        issueCompletionCount: missing,
+        issueUnresponsiveCount: missing,
+        issueCommentFrequencyMean: missing,
+      },
+      pullsDetailOverview: {
+        pullCount: missing,
+        pullCompletionRatio: missing,
+        pullUnresponsiveCount: missing,
+        commitCount: missing,
+      },
+    });
+    mount();
+    await screen.findByText('analyze:metric_detail:contributor_count');
+    for (const name of [
+      'contributor_count',
+      'newly_created_issues',
+      'unanswered_issue_count',
+      'average_comments_count',
+      'newly_created_pr_count',
+      'pr_completion_rate',
+      'unanswered_pr_count',
+      'commit_count',
+    ])
+      expect(valueOf(name)).toBe('/');
+    expect(valueOf('issue_completion_rate')).toBe('0% (/)');
+  }
+);
+it('does not apply a late status response to the newly selected report', async () => {
+  const old = deferred<ReturnType<typeof analysis>>();
+  request.mockImplementation(({ document, variables }) =>
+    document.includes('query statusVerify')
+      ? variables.shortCode === 'a'
+        ? old.promise
+        : Promise.resolve(analysis('progress', 'b'))
+      : Promise.resolve(zeroMetrics)
+  );
+  const view = mount();
+  mockIds = ['b'];
+  view.refresh();
+  await screen.findByText(pendingText);
+  await act(async () => old.resolve(analysis('success', 'a')));
+  expect(screen.getByText(pendingText)).toBeInTheDocument();
+  expect(metricCalls()).toHaveLength(0);
+});
+it('hides the previous report immediately while the new status is loading', async () => {
+  const view = mount();
+  await screen.findByText('analyze:metric_detail:contributor_count');
+  request.mockReturnValue(new Promise(() => {}));
+  mockIds = ['b'];
+  view.refresh();
+  expect(
+    screen.getByRole('status', { name: 'common:loading' })
+  ).toBeInTheDocument();
+  expect(
+    screen.queryByText('analyze:metric_detail:contributor_count')
+  ).not.toBeInTheDocument();
+});
+it('ignores late metric responses when the date range changes', async () => {
+  const old = deferred<typeof zeroMetrics>();
+  const recent = deferred<typeof zeroMetrics>();
+  request.mockImplementation(({ document, variables }) =>
+    document.includes('query statusVerify')
+      ? Promise.resolve(analysis())
+      : variables.beginDate === '2026-01-01'
+      ? old.promise
+      : recent.promise
+  );
+  const view = mount();
+  await waitFor(() => expect(metricCalls()).toHaveLength(1));
+  mockStart = '2026-03-01';
+  view.refresh();
+  await waitFor(() => expect(metricCalls()).toHaveLength(2));
+  await act(async () => recent.resolve(zeroMetrics));
+  await waitFor(() => expect(valueOf('contributor_count')).toBe('0'));
+  await act(async () =>
+    old.resolve({
+      ...zeroMetrics,
+      contributorsDetailOverview: { contributorAllCount: 999, orgAllCount: 3 },
+    })
+  );
+  expect(valueOf('contributor_count')).toBe('0');
+  expect(screen.queryByText('999')).not.toBeInTheDocument();
+});

--- a/apps/web/src/modules/analyze/DataView/MetricDetail/MetricDashboard.tsx
+++ b/apps/web/src/modules/analyze/DataView/MetricDetail/MetricDashboard.tsx
@@ -21,6 +21,7 @@ import { SiGitee, SiGithub } from 'react-icons/si';
 import { toFixed } from '@common/utils';
 import { useRouter } from 'next/router';
 import Image from 'next/image';
+import AnalysisStatus, { AnalysisFeedback } from '../Status/AnalysisStatus';
 
 const MetricDashboard = () => {
   const { compareItems } = useCompareItems();
@@ -28,7 +29,11 @@ const MetricDashboard = () => {
   if (len > 1) {
     return null;
   }
-  return <Main />;
+  return (
+    <AnalysisStatus>
+      {len === 1 ? <Main key={compareItems[0].label} /> : null}
+    </AnalysisStatus>
+  );
 };
 
 const Main = () => {
@@ -38,43 +43,39 @@ const Main = () => {
   const router = useRouter();
   const slugs = router.query.slugs;
   const { label, level } = compareItems[0];
-  const { data, isLoading } = useMetricDashboardQuery(client, {
-    label: label,
-    level: level,
-    beginDate: timeStart,
-    endDate: timeEnd,
-  });
+  const { data, isLoading, isError, refetch } = useMetricDashboardQuery(
+    client,
+    { label, level, beginDate: timeStart, endDate: timeEnd },
+    { keepPreviousData: false }
+  );
+  const contributors = data?.contributorsDetailOverview;
+  const issues = data?.issuesDetailOverview;
+  const pulls = data?.pullsDetailOverview;
+  const hasData = [
+    contributors?.contributorAllCount,
+    contributors?.orgAllCount,
+    contributors?.highestContributionContributor?.name,
+    contributors?.highestContributionOrganization?.name,
+    issues?.issueCount,
+    issues?.issueCompletionRatio,
+    issues?.issueCompletionCount,
+    issues?.issueUnresponsiveCount,
+    issues?.issueCommentFrequencyMean,
+    pulls?.pullCount,
+    pulls?.pullCompletionRatio,
+    pulls?.pullCompletionCount,
+    pulls?.pullUnresponsiveCount,
+    pulls?.commitCount,
+  ].some((value) => value != null);
 
-  if (isLoading) {
-    return (
-      <>
-        <div className="mt-6 mb-2 flex justify-between">
-          <div className="text-xl font-semibold text-[#000000]">
-            {t('analyze:metric_detail:project_deep_dive_insight')}
-          </div>
-          <div
-            className="flex cursor-pointer items-center gap-2 rounded border border-[#3A5BEF] py-1.5 px-3 text-xs text-[#3A5BEF]"
-            onClick={() => {
-              const query = window.location.search;
-              router.push('/analyze/insight/' + slugs + query);
-            }}
-          >
-            {t('analyze:metric_detail:details')}
-            <AiOutlineArrowRight />
-          </div>
-        </div>
-        <Loading />
-      </>
-    );
-  }
   return (
     <div>
-      <div className="mt-6 mb-2 flex justify-between">
+      <div className="mb-2 mt-6 flex justify-between">
         <div className="text-xl font-semibold text-[#000000]">
           {t('analyze:metric_detail:project_deep_dive_insight')}
         </div>
         <div
-          className="flex cursor-pointer items-center gap-2 rounded border border-[#3A5BEF] py-1.5 px-3 text-xs text-[#3A5BEF]"
+          className="flex cursor-pointer items-center gap-2 rounded border border-[#3A5BEF] px-3 py-1.5 text-xs text-[#3A5BEF]"
           onClick={() => {
             const query = window.location.search;
             router.push('/analyze/insight/' + slugs + query);
@@ -84,13 +85,21 @@ const Main = () => {
           <AiOutlineArrowRight />
         </div>
       </div>
-      <div className="base-card rounded-lg border-2 border-b border-transparent bg-white drop-shadow-sm md:rounded-none">
-        <MetricBoxContributors data={data?.contributorsDetailOverview} />
-        <div className="grid grid-cols-2">
-          <MetricBoxIssues data={data?.issuesDetailOverview} />
-          <MetricBoxPr data={data?.pullsDetailOverview} />
+      {isLoading ? (
+        <AnalysisFeedback state="loading" />
+      ) : isError ? (
+        <AnalysisFeedback state="error" onRetry={refetch} />
+      ) : !hasData ? (
+        <AnalysisFeedback state="empty" />
+      ) : (
+        <div className="base-card rounded-lg border-2 border-b border-transparent bg-white drop-shadow-sm md:rounded-none">
+          <MetricBoxContributors data={data?.contributorsDetailOverview} />
+          <div className="grid grid-cols-2">
+            <MetricBoxIssues data={data?.issuesDetailOverview} />
+            <MetricBoxPr data={data?.pullsDetailOverview} />
+          </div>
         </div>
-      </div>
+      )}
     </div>
   );
 };
@@ -108,10 +117,10 @@ const MetricBoxContributors: React.FC<{
             {t('analyze:metric_detail:contributor')}
           </div>
         </div>
-        <div className="mt-4 mb-2 grid grid-cols-4 gap-4 pl-12">
+        <div className="mb-2 mt-4 grid grid-cols-4 gap-4 pl-12">
           <div>
             <div className="flex text-xl font-medium">
-              <div className="mt-1 mr-2 text-[#ccc]">
+              <div className="mr-2 mt-1 text-[#ccc]">
                 <IoPersonCircle />
               </div>
               <div className="line-clamp-1">-</div>
@@ -122,7 +131,7 @@ const MetricBoxContributors: React.FC<{
           </div>
           <div>
             <div className="flex text-xl font-medium">
-              <div className="mt-1 mr-2 text-[#ccc]">
+              <div className="mr-2 mt-1 text-[#ccc]">
                 <IoPersonCircle />
               </div>
               <div className="line-clamp-1">-</div>
@@ -133,7 +142,7 @@ const MetricBoxContributors: React.FC<{
           </div>
           <div>
             <div className="flex text-xl font-medium">
-              <div className="mt-1 mr-2 text-[#ccc]">
+              <div className="mr-2 mt-1 text-[#ccc]">
                 <IoPeopleCircle />
               </div>
               <div className="line-clamp-1">-</div>
@@ -144,7 +153,7 @@ const MetricBoxContributors: React.FC<{
           </div>
           <div>
             <div className="flex text-xl font-medium">
-              <div className="mt-1 mr-2 text-[#ccc]">
+              <div className="mr-2 mt-1 text-[#ccc]">
                 <IoPeopleCircle />
               </div>
               <div className="line-clamp-1">-</div>
@@ -165,13 +174,15 @@ const MetricBoxContributors: React.FC<{
           {t('analyze:metric_detail:contributor')}
         </div>
       </div>
-      <div className="mt-4 mb-2 grid grid-cols-4 gap-4 pl-12">
+      <div className="mb-2 mt-4 grid grid-cols-4 gap-4 pl-12">
         <div>
           <div className="flex text-xl font-medium">
-            <div className="mt-1 mr-2 text-[#ccc]">
+            <div className="mr-2 mt-1 text-[#ccc]">
               <IoPersonCircle />
             </div>
-            <div className="line-clamp-1">{data.contributorAllCount || 0}</div>
+            <div className="line-clamp-1">
+              {data.contributorAllCount ?? '/'}
+            </div>
           </div>
           <div className="line-clamp-1 pl-7 text-sm text-[#585858]">
             {t('analyze:metric_detail:contributor_count')}
@@ -190,10 +201,10 @@ const MetricBoxContributors: React.FC<{
         </div>
         <div>
           <div className="flex text-xl font-medium">
-            <div className="mt-1 mr-2 text-[#ccc]">
+            <div className="mr-2 mt-1 text-[#ccc]">
               <IoPeopleCircle />
             </div>
-            <div className="line-clamp-1">{data.orgAllCount || 0}</div>
+            <div className="line-clamp-1">{data.orgAllCount ?? '/'}</div>
           </div>
           <div className="line-clamp-1 pl-7 text-sm text-[#585858]">
             {t('analyze:metric_detail:org_count')}
@@ -201,7 +212,7 @@ const MetricBoxContributors: React.FC<{
         </div>
         <div>
           <div className="flex text-xl font-medium">
-            <div className="mt-1 mr-2 text-[#ccc]">
+            <div className="mr-2 mt-1 text-[#ccc]">
               {getIcons(data.highestContributionOrganization?.origin)}
             </div>
             <div className="line-clamp-1">
@@ -229,10 +240,10 @@ const MetricBoxIssues: React.FC<{
             {t('analyze:metric_detail:issues')}
           </div>
         </div>
-        <div className="mt-4 mb-2 grid grid-cols-2 gap-4 pl-12">
+        <div className="mb-2 mt-4 grid grid-cols-2 gap-4 pl-12">
           <div>
             <div className="flex text-xl font-medium">
-              <div className="mt-1 mr-2 text-[#ccc]">
+              <div className="mr-2 mt-1 text-[#ccc]">
                 <GoIssueOpened />
               </div>
               <div className="line-clamp-1">-</div>
@@ -243,7 +254,7 @@ const MetricBoxIssues: React.FC<{
           </div>
           <div>
             <div className="flex text-xl font-medium">
-              <div className="mt-1 mr-2 text-[#ccc]">
+              <div className="mr-2 mt-1 text-[#ccc]">
                 <AiOutlineIssuesClose />
               </div>
               <div className="line-clamp-1">-</div>
@@ -254,7 +265,7 @@ const MetricBoxIssues: React.FC<{
           </div>
           <div>
             <div className="flex text-xl font-medium">
-              <div className="mt-1 mr-2 text-[#ccc]">
+              <div className="mr-2 mt-1 text-[#ccc]">
                 <AiFillClockCircle />
               </div>
               <div className="line-clamp-1">-</div>
@@ -265,7 +276,7 @@ const MetricBoxIssues: React.FC<{
           </div>
           <div>
             <div className="flex text-xl font-medium">
-              <div className="mt-1 mr-2 text-[#ccc]">
+              <div className="mr-2 mt-1 text-[#ccc]">
                 <BiChat />
               </div>
               <div className="line-clamp-1">-</div>
@@ -286,13 +297,13 @@ const MetricBoxIssues: React.FC<{
           {t('analyze:metric_detail:issues')}
         </div>
       </div>
-      <div className="mt-4 mb-2 grid grid-cols-2 gap-4 pl-12">
+      <div className="mb-2 mt-4 grid grid-cols-2 gap-4 pl-12">
         <div>
           <div className="flex text-xl font-medium">
-            <div className="mt-1 mr-2 text-[#ccc]">
+            <div className="mr-2 mt-1 text-[#ccc]">
               <GoIssueOpened />
             </div>
-            <div className="line-clamp-1">{data.issueCount || 0}</div>
+            <div className="line-clamp-1">{data.issueCount ?? '/'}</div>
           </div>
           <div className="line-clamp-1 pl-7 text-sm text-[#585858]">
             {t('analyze:metric_detail:newly_created_issues')}
@@ -300,14 +311,14 @@ const MetricBoxIssues: React.FC<{
         </div>
         <div>
           <div className="flex text-xl font-medium">
-            <div className="mt-1 mr-2 text-[#ccc]">
+            <div className="mr-2 mt-1 text-[#ccc]">
               <AiOutlineIssuesClose />
             </div>
             <div className="line-clamp-1">
-              {data.issueCompletionRatio
+              {data.issueCompletionRatio != null
                 ? toFixed(data.issueCompletionRatio * 100, 1) +
                   '% (' +
-                  (data.issueCompletionCount || 0) +
+                  (data.issueCompletionCount ?? '/') +
                   ')'
                 : '/'}
             </div>
@@ -318,11 +329,11 @@ const MetricBoxIssues: React.FC<{
         </div>
         <div>
           <div className="flex text-xl font-medium">
-            <div className="mt-1 mr-2 text-[#ccc]">
+            <div className="mr-2 mt-1 text-[#ccc]">
               <AiFillClockCircle />
             </div>
             <div className="line-clamp-1">
-              {data.issueUnresponsiveCount || 0}
+              {data.issueUnresponsiveCount ?? '/'}
             </div>
           </div>
           <div className="line-clamp-1 pl-7 text-sm text-[#585858]">
@@ -331,13 +342,13 @@ const MetricBoxIssues: React.FC<{
         </div>
         <div>
           <div className="flex text-xl font-medium">
-            <div className="mt-1 mr-2 text-[#ccc]">
+            <div className="mr-2 mt-1 text-[#ccc]">
               <BiChat />
             </div>
             <div className="line-clamp-1">
-              {data.issueCommentFrequencyMean
+              {data.issueCommentFrequencyMean != null
                 ? toFixed(data.issueCommentFrequencyMean, 2)
-                : 0}
+                : '/'}
             </div>
           </div>
           <div className="line-clamp-1 pl-7 text-sm text-[#585858]">
@@ -362,10 +373,10 @@ const MetricBoxPr: React.FC<{
             {t('analyze:metric_detail:pull_requests')}
           </div>
         </div>
-        <div className="mt-4 mb-2 grid grid-cols-2 gap-4 pl-12">
+        <div className="mb-2 mt-4 grid grid-cols-2 gap-4 pl-12">
           <div>
             <div className="flex text-xl font-medium">
-              <div className="line-clamp-1 mt-1 mr-2 text-[#ccc]">
+              <div className="mr-2 mt-1 line-clamp-1 text-[#ccc]">
                 <BiGitPullRequest />
               </div>
               <div className="line-clamp-1">-</div>
@@ -376,7 +387,7 @@ const MetricBoxPr: React.FC<{
           </div>
           <div>
             <div className="flex text-xl font-medium">
-              <div className="mt-1 mr-2 text-[#ccc]">
+              <div className="mr-2 mt-1 text-[#ccc]">
                 <GoGitPullRequestClosed />
               </div>
               <div className="line-clamp-1">-</div>
@@ -387,7 +398,7 @@ const MetricBoxPr: React.FC<{
           </div>
           <div>
             <div className="flex text-xl font-medium">
-              <div className="mt-1 mr-2 text-[#ccc]">
+              <div className="mr-2 mt-1 text-[#ccc]">
                 <AiFillClockCircle />
               </div>
               <div className="line-clamp-1">-</div>
@@ -398,7 +409,7 @@ const MetricBoxPr: React.FC<{
           </div>
           <div>
             <div className="flex text-xl font-medium">
-              <div className="mt-1 mr-2 text-[#ccc]">
+              <div className="mr-2 mt-1 text-[#ccc]">
                 <BiGitCommit />
               </div>
               <div className="line-clamp-1">-</div>
@@ -419,13 +430,13 @@ const MetricBoxPr: React.FC<{
           {t('analyze:metric_detail:pull_requests')}
         </div>
       </div>
-      <div className="mt-4 mb-2 grid grid-cols-2 gap-4 pl-12">
+      <div className="mb-2 mt-4 grid grid-cols-2 gap-4 pl-12">
         <div>
           <div className="flex text-xl font-medium">
-            <div className="line-clamp-1 mt-1 mr-2 text-[#ccc]">
+            <div className="mr-2 mt-1 line-clamp-1 text-[#ccc]">
               <BiGitPullRequest />
             </div>
-            <div className="line-clamp-1">{data.pullCount || 0}</div>
+            <div className="line-clamp-1">{data.pullCount ?? '/'}</div>
           </div>
           <div className="line-clamp-1 pl-7 text-sm text-[#585858]">
             {t('analyze:metric_detail:newly_created_pr_count')}
@@ -433,14 +444,14 @@ const MetricBoxPr: React.FC<{
         </div>
         <div>
           <div className="flex text-xl font-medium">
-            <div className="mt-1 mr-2 text-[#ccc]">
+            <div className="mr-2 mt-1 text-[#ccc]">
               <GoGitPullRequestClosed />
             </div>
             <div className="line-clamp-1">
-              {data.pullCompletionRatio
+              {data.pullCompletionRatio != null
                 ? toFixed(data.pullCompletionRatio * 100, 1) +
                   '% (' +
-                  (data.pullCompletionCount || 0) +
+                  (data.pullCompletionCount ?? '/') +
                   ')'
                 : '/'}
             </div>
@@ -451,11 +462,11 @@ const MetricBoxPr: React.FC<{
         </div>
         <div>
           <div className="flex text-xl font-medium">
-            <div className="mt-1 mr-2 text-[#ccc]">
+            <div className="mr-2 mt-1 text-[#ccc]">
               <AiFillClockCircle />
             </div>
             <div className="line-clamp-1">
-              {data.pullUnresponsiveCount || 0}
+              {data.pullUnresponsiveCount ?? '/'}
             </div>
           </div>
           <div className="line-clamp-1 pl-7 text-sm text-[#585858]">
@@ -464,10 +475,10 @@ const MetricBoxPr: React.FC<{
         </div>
         <div>
           <div className="flex text-xl font-medium">
-            <div className="mt-1 mr-2 text-[#ccc]">
+            <div className="mr-2 mt-1 text-[#ccc]">
               <BiGitCommit />
             </div>
-            <div className="line-clamp-1">{data.commitCount || 0}</div>
+            <div className="line-clamp-1">{data.commitCount ?? '/'}</div>
           </div>
           <div className="line-clamp-1 pl-7 text-sm text-[#585858]">
             {t('analyze:metric_detail:commit_count')}
@@ -477,23 +488,6 @@ const MetricBoxPr: React.FC<{
     </div>
   );
 };
-const Loading = () => (
-  <div className="h-[348px] animate-pulse rounded border bg-white p-10 px-6 py-6 shadow">
-    <div className="flex-1 space-y-4">
-      <div className="h-4 rounded bg-slate-200"></div>
-      <div className="grid grid-cols-3 gap-4">
-        <div className="col-span-2 h-4 rounded bg-slate-200"></div>
-        <div className="col-span-1 h-4 rounded bg-slate-200"></div>
-      </div>
-      <div className="h-4 rounded bg-slate-200"></div>
-      <div className="grid grid-cols-3 gap-4">
-        <div className="col-span-1 h-4 rounded bg-slate-200"></div>
-        <div className="col-span-2 h-4 rounded bg-slate-200"></div>
-      </div>
-      <div className="h-4 rounded bg-slate-200"></div>
-    </div>
-  </div>
-);
 const getIcons = (type: string) => {
   if (!type) {
     return <IoPeopleCircle />;
@@ -586,7 +580,7 @@ const getTopUser = (type, name) => {
 
   return (
     <>
-      <div className="mt-1 mr-2 text-[#ccc]">{userIcon}</div>
+      <div className="mr-2 mt-1 text-[#ccc]">{userIcon}</div>
       <div className="line-clamp-1">
         {url ? (
           <a

--- a/apps/web/src/modules/analyze/DataView/MetricDetail/index.test.tsx
+++ b/apps/web/src/modules/analyze/DataView/MetricDetail/index.test.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import client from '@common/gqlClient';
+import {
+  ConfigValue,
+  DEFAULT_CONFIG,
+  StatusContextProvider,
+} from '@modules/analyze/context';
+import { Level } from '@modules/analyze/constant';
+import MetricDetail from './index';
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+jest.mock('next/router', () => ({
+  useRouter: () => ({ query: { slugs: 'a' } }),
+}));
+jest.mock('@common/gqlClient', () => ({
+  __esModule: true,
+  default: { request: jest.fn() },
+}));
+jest.mock('@modules/analyze/hooks/useHandleQueryParams', () => ({
+  useHandleQueryParams: () => ({ handleQueryParams: jest.fn() }),
+}));
+jest.mock('@common/components/Tab', () => () => null);
+jest.mock(
+  '@modules/analyze/components/NavBar/MerticDatePicker',
+  () => () => null
+);
+jest.mock('@modules/analyze/components/NavBar/LabelItems', () => () => null);
+jest.mock('antd', () => ({ Select: () => null }));
+jest.mock(
+  './MetricContributor',
+  () =>
+    function MetricContributor() {
+      return <div>Contributor details</div>;
+    }
+);
+jest.mock(
+  './MetricIssue',
+  () =>
+    function MetricIssue() {
+      return <div>Issue details</div>;
+    }
+);
+jest.mock(
+  './MetricPr',
+  () =>
+    function MetricPr() {
+      return <div>PR details</div>;
+    }
+);
+
+const request = client.request as jest.Mock;
+let queryClient: QueryClient;
+const ready: ConfigValue = {
+  ...DEFAULT_CONFIG,
+  status: 'success',
+  verifiedItems: [
+    {
+      label: 'https://github.com/compass/a',
+      shortCode: 'a',
+      level: Level.REPO,
+      status: 'success',
+      collections: [],
+    },
+  ],
+};
+function mount(status = ready) {
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <StatusContextProvider value={status}>
+        <MetricDetail />
+      </StatusContextProvider>
+    </QueryClientProvider>
+  );
+}
+beforeEach(() => {
+  request.mockReset();
+  queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+    logger: { log: console.log, warn: console.warn, error: () => {} },
+  });
+});
+afterEach(() => queryClient.clear());
+it.each(['pending', 'progress'])(
+  'gates the detail route while the task is %s',
+  async (status) => {
+    mount({ ...ready, status });
+    expect(
+      screen.getByText(
+        'analyze:the_current_project_is_under_analysis_please_visit'
+      )
+    ).toBeInTheDocument();
+    expect(request).not.toHaveBeenCalled();
+    expect(screen.queryByText('Contributor details')).not.toBeInTheDocument();
+  }
+);
+it('gates task failure without querying the detail date range', () => {
+  mount({ ...ready, status: 'error' });
+  expect(screen.getByRole('alert')).toBeInTheDocument();
+  expect(request).not.toHaveBeenCalled();
+});
+it('shows loading while the detail date range is being verified', () => {
+  request.mockReturnValue(new Promise(() => {}));
+  mount();
+  expect(
+    screen.getByRole('status', { name: 'common:loading' })
+  ).toBeInTheDocument();
+  expect(screen.queryByText('Contributor details')).not.toBeInTheDocument();
+});
+it('retries a failed date verification before mounting detail data', async () => {
+  request
+    .mockRejectedValueOnce(new Error('Verification failed'))
+    .mockResolvedValueOnce({
+      verifyDetailDataRange: { status: true, labelAdmin: false },
+    });
+  mount();
+  await screen.findByRole('alert');
+  expect(screen.queryByText('Contributor details')).not.toBeInTheDocument();
+  fireEvent.click(
+    screen.getByRole('button', { name: 'common:error.try_again' })
+  );
+  expect(await screen.findByText('Contributor details')).toBeInTheDocument();
+  expect(request).toHaveBeenCalledTimes(2);
+});
+it('does not interpret the date-permission boolean as task progress', async () => {
+  request.mockResolvedValue({
+    verifyDetailDataRange: { status: false, labelAdmin: false },
+  });
+  mount();
+  expect(await screen.findByText('Contributor details')).toBeInTheDocument();
+  expect(
+    screen.queryByText(
+      'analyze:the_current_project_is_under_analysis_please_visit'
+    )
+  ).not.toBeInTheDocument();
+});

--- a/apps/web/src/modules/analyze/DataView/MetricDetail/index.tsx
+++ b/apps/web/src/modules/analyze/DataView/MetricDetail/index.tsx
@@ -6,32 +6,38 @@ import MetricIssue from './MetricIssue';
 import MetricPr from './MetricPr';
 import { AiOutlineLeftCircle } from 'react-icons/ai';
 import MerticDatePicker from '@modules/analyze/components/NavBar/MerticDatePicker';
-import useLabelStatus from '@modules/analyze/hooks/useLabelStatus';
+import { useStatusContext } from '@modules/analyze/context';
 import { withErrorBoundary } from 'react-error-boundary';
 import ErrorFallback from '@common/components/ErrorFallback';
 import useVerifyDetailRangeQuery from '@modules/analyze/hooks/useVerifyDetailRangeQuery';
-import LoadingAnalysis from '@modules/analyze/DataView/Status/LoadingAnalysis';
+import AnalysisStatus, { AnalysisFeedback } from '../Status/AnalysisStatus';
 import LabelItems from '@modules/analyze/components/NavBar/LabelItems';
 import { useRouter } from 'next/router';
 import { useHandleQueryParams } from '@modules/analyze/hooks/useHandleQueryParams';
 import { Select } from 'antd';
 
 const VerifyMetricDetail = () => {
-  const { isLoading } = useVerifyDetailRangeQuery();
+  const { isLoading, isError, refetch } = useVerifyDetailRangeQuery();
   if (isLoading) {
-    return <LoadingAnalysis />;
+    return <AnalysisFeedback state="loading" />;
   }
+  if (isError) return <AnalysisFeedback state="error" onRetry={refetch} />;
   return <MetricDetail />;
 };
+const MetricDetailStatus = () => (
+  <AnalysisStatus>
+    <VerifyMetricDetail />
+  </AnalysisStatus>
+);
 const MetricDetail = () => {
   const { t } = useTranslation();
   const router = useRouter();
   const { handleQueryParams } = useHandleQueryParams();
   const slugs = router.query.slugs;
   const queryTab = router.query?.tab as string;
-  const { isLoading, verifiedItems } = useLabelStatus();
+  const { verifiedItems } = useStatusContext();
   const [tab, setTab] = useState<string>(queryTab || 'contributor');
-  if (isLoading || verifiedItems.length > 1) {
+  if (verifiedItems.length !== 1) {
     return null;
   }
 
@@ -112,7 +118,7 @@ const MetricDetail = () => {
   );
 };
 
-export default withErrorBoundary(VerifyMetricDetail, {
+export default withErrorBoundary(MetricDetailStatus, {
   FallbackComponent: ErrorFallback,
   onError(error, info) {
     console.log(error, info);

--- a/apps/web/src/modules/analyze/DataView/Status/AnalysisStatus.tsx
+++ b/apps/web/src/modules/analyze/DataView/Status/AnalysisStatus.tsx
@@ -1,0 +1,71 @@
+import React, { PropsWithChildren } from 'react';
+import { useTranslation } from 'next-i18next';
+import { useStatusContext } from '@modules/analyze/context';
+import LoadingAnalysis from './LoadingAnalysis';
+import NotFoundAnalysis from './NotFoundAnalysis';
+import UnderAnalysis from './UnderAnalysis';
+
+export const AnalysisFeedback = ({
+  state,
+  onRetry,
+}: {
+  state: 'loading' | 'pending' | 'error' | 'empty';
+  onRetry?: () => void;
+}) => {
+  const { t } = useTranslation();
+  if (state === 'loading') {
+    return (
+      <div role="status" aria-label={t('common:loading')} aria-busy="true">
+        <LoadingAnalysis />
+      </div>
+    );
+  }
+  if (state === 'pending') {
+    return (
+      <div role="status" className="py-10">
+        <UnderAnalysis />
+      </div>
+    );
+  }
+  return (
+    <div
+      role={state === 'error' ? 'alert' : 'status'}
+      className="flex flex-col items-center gap-4 p-10 text-center text-gray-600"
+    >
+      <p>
+        {t(
+          state === 'error'
+            ? 'common:error.something_went_wrong'
+            : 'common:no_data'
+        )}
+      </p>
+      {state === 'error' && onRetry && (
+        <button
+          type="button"
+          className="rounded border border-blue-600 px-4 py-2 text-blue-600"
+          onClick={onRetry}
+        >
+          {t('common:error.try_again')}
+        </button>
+      )}
+    </div>
+  );
+};
+
+const AnalysisStatus: React.FC<PropsWithChildren> = ({ children }) => {
+  const { isLoading, isError, status, notFound, refetch } = useStatusContext();
+  if (isLoading) return <AnalysisFeedback state="loading" />;
+  if (isError || status === 'error') {
+    return <AnalysisFeedback state="error" onRetry={refetch} />;
+  }
+  if (notFound) return <NotFoundAnalysis />;
+  if (status === 'pending' || status === 'progress') {
+    return <AnalysisFeedback state="pending" />;
+  }
+  if (status !== 'success') {
+    return <AnalysisFeedback state="error" onRetry={refetch} />;
+  }
+  return <>{children}</>;
+};
+
+export default AnalysisStatus;

--- a/apps/web/src/modules/analyze/DataView/index.tsx
+++ b/apps/web/src/modules/analyze/DataView/index.tsx
@@ -1,32 +1,16 @@
 import React from 'react';
-import { useStatusContext } from '@modules/analyze/context';
-import { checkIsPending } from '@modules/analyze/constant';
+import AnalysisStatus from './Status/AnalysisStatus';
 import CompareBar from '@modules/analyze/components/CompareBar';
-import UnderAnalysis from './Status/UnderAnalysis';
-import NotFoundAnalysis from './Status/NotFoundAnalysis';
-import LoadingAnalysis from './Status/LoadingAnalysis';
 import Charts from './Charts';
 
 const DataView = () => {
-  const { notFound, isLoading, status } = useStatusContext();
-
-  if (isLoading) {
-    return <LoadingAnalysis />;
-  }
-
-  if (!notFound && checkIsPending(status)) {
-    return <UnderAnalysis />;
-  }
-
-  if (notFound) {
-    return <NotFoundAnalysis />;
-  }
-
   return (
-    <div className="mx-auto w-full flex-1">
-      <CompareBar />
-      <Charts />
-    </div>
+    <AnalysisStatus>
+      <div className="mx-auto w-full flex-1">
+        <CompareBar />
+        <Charts />
+      </div>
+    </AnalysisStatus>
   );
 };
 

--- a/apps/web/src/modules/analyze/components/Container/AnalyzeContainer.tsx
+++ b/apps/web/src/modules/analyze/components/Container/AnalyzeContainer.tsx
@@ -5,13 +5,11 @@ import PageInfoInit from '@modules/analyze/components/PageInfoInit';
 import NoSsr from '@common/components/NoSsr';
 
 const AnalyzeContainer: React.FC<PropsWithChildren> = ({ children }) => {
-  const { status, isLoading, notFound, verifiedItems } = useLabelStatus();
+  const status = useLabelStatus();
 
   return (
     <NoSsr>
-      <StatusContextProvider
-        value={{ status, notFound, verifiedItems, isLoading }}
-      >
+      <StatusContextProvider value={status}>
         <PageInfoInit>{children}</PageInfoInit>
       </StatusContextProvider>
     </NoSsr>

--- a/apps/web/src/modules/analyze/context/StatusContext.tsx
+++ b/apps/web/src/modules/analyze/context/StatusContext.tsx
@@ -14,15 +14,19 @@ export type VerifiedLabelItem = {
 export interface ConfigValue {
   status: string;
   isLoading: boolean;
+  isError: boolean;
   notFound: boolean;
   verifiedItems: VerifiedLabelItem[];
+  refetch: () => void;
 }
 
 export const DEFAULT_CONFIG: ConfigValue = {
   status: '',
   isLoading: false,
+  isError: false,
   notFound: false,
   verifiedItems: [],
+  refetch: () => {},
 };
 
 export const StatusContext = createContext<ConfigValue>(DEFAULT_CONFIG);

--- a/apps/web/src/modules/analyze/hooks/useLabelStatus.ts
+++ b/apps/web/src/modules/analyze/hooks/useLabelStatus.ts
@@ -1,65 +1,66 @@
 import client from '@common/gqlClient';
-import { StatusVerifyQuery, useStatusVerifyQuery } from '@oss-compass/graphql';
-import { useQueries, useQueryClient } from '@tanstack/react-query';
+import { useStatusVerifyQuery } from '@oss-compass/graphql';
+import { useQueries } from '@tanstack/react-query';
 import useExtractShortIds from './useExtractShortIds';
-import { VerifiedLabelItem } from '@modules/analyze/context';
+import { ConfigValue, VerifiedLabelItem } from '@modules/analyze/context';
 
-function nonNullable<T>(value: T): value is NonNullable<T> {
-  return value !== null && value !== undefined;
-}
+// This endpoint reports project status, not independent insight-stage readiness.
+// See docs/insight-analysis-states.md for the backend contract.
+const activeStatuses = ['pending', 'progress'];
+const knownStatuses = [...activeStatuses, 'success', 'error', 'canceled'];
 
-const useLabelStatus = () => {
-  const queryClient = useQueryClient();
+const useLabelStatus = (): ConfigValue => {
   const { shortIds } = useExtractShortIds();
-
   const queries = useQueries({
-    queries: shortIds.map((shortCode) => {
-      return {
-        queryKey: useStatusVerifyQuery.getKey({ shortCode }),
-        queryFn: useStatusVerifyQuery.fetcher(client, { shortCode }),
-      };
-    }),
+    queries: shortIds.map((shortCode) => ({
+      queryKey: useStatusVerifyQuery.getKey({ shortCode }),
+      queryFn: useStatusVerifyQuery.fetcher(client, { shortCode }),
+      keepPreviousData: false,
+      staleTime: 5000,
+      refetchInterval: (data, query) =>
+        query.state.status !== 'error' &&
+        activeStatuses.includes(data?.analysisStatusVerify.status || '')
+          ? 5000
+          : false,
+    })),
   });
 
+  const items = queries.map((query) => query.data?.analysisStatusVerify);
   const isLoading = queries.some((query) => query.isLoading);
+  const isError = queries.some((query) => query.isError);
+  const verifiedItems = items.filter(
+    (item) => item?.label && knownStatuses.includes(item.status || '')
+  ) as VerifiedLabelItem[];
+  const notFound =
+    shortIds.length === 0 ||
+    items.some((item) => !item?.label || item.status === 'unsubmit');
+  // Unknown task states must not become an endless "under analysis" screen.
+  const failed = items.some(
+    (item) =>
+      item?.label &&
+      item.status !== 'unsubmit' &&
+      ![...activeStatuses, 'success'].includes(item.status || '')
+  );
+  const status = failed
+    ? 'error'
+    : items.some((item) => item?.status === 'progress')
+    ? 'progress'
+    : items.some((item) => item?.status === 'pending')
+    ? 'pending'
+    : !notFound && items.every((item) => item?.status === 'success')
+    ? 'success'
+    : '';
 
-  const queriesResult = shortIds.map((shortCode) => {
-    const key = useStatusVerifyQuery.getKey({ shortCode });
-    const data = queryClient.getQueryData<StatusVerifyQuery>(key);
-    return { ...data?.analysisStatusVerify };
-  });
-
-  // server verified Items
-  const verifiedItems = queriesResult
-    .filter(nonNullable)
-    .filter((item) => Boolean(item?.label))
-    .filter((item) => {
-      return ['pending', 'progress', 'success'].includes(item?.status || '');
-    }) as VerifiedLabelItem[];
-
-  // single
-  if (verifiedItems.length === 1) {
-    return {
-      isLoading,
-      status: verifiedItems[0].status || '',
-      notFound: false,
-      verifiedItems,
-    };
-  }
-
-  //  compare
-  if (verifiedItems.length > 1) {
-    const isSuccess = verifiedItems.every(({ status }) => status === 'success');
-    return {
-      isLoading,
-      status: isSuccess ? 'success' : 'progress',
-      notFound: false,
-      verifiedItems,
-    };
-  }
-
-  // not found
-  return { isLoading, status: '', verifiedItems: [], notFound: true };
+  return {
+    isLoading,
+    isError,
+    status,
+    notFound,
+    verifiedItems,
+    refetch: () => {
+      queries.forEach((query) => void query.refetch());
+    },
+  };
 };
 
 export default useLabelStatus;

--- a/apps/web/src/modules/analyze/hooks/useVerifyDetailRangeQuery.ts
+++ b/apps/web/src/modules/analyze/hooks/useVerifyDetailRangeQuery.ts
@@ -8,7 +8,7 @@ const useVerifyDetailRangeQuery = () => {
   const beginDate = timeRange['1Y'].start;
   const endDate = timeRange['1Y'].end;
 
-  const { data, isLoading } = useVerifyDetailDataRangeQuery(
+  const { data, isLoading, isError, refetch } = useVerifyDetailDataRangeQuery(
     client,
     {
       shortCode: shortIds[0],
@@ -17,10 +17,11 @@ const useVerifyDetailRangeQuery = () => {
     },
     {
       staleTime: 300000, // 5 minutes
+      keepPreviousData: false,
     }
   );
 
-  return { isLoading, data };
+  return { isLoading, isError, refetch, data };
 };
 
 export default useVerifyDetailRangeQuery;

--- a/docs/insight-analysis-states.md
+++ b/docs/insight-analysis-states.md
@@ -1,0 +1,35 @@
+# Insight analysis states
+
+The analysis pages use `analysisStatusVerify` for **project-level** task status. A metric value (including zero) must never be used to infer task progress.
+
+| Input                                          | Presentation                                                 | Recovery                                                   |
+| ---------------------------------------------- | ------------------------------------------------------------ | ---------------------------------------------------------- |
+| Status request has no response yet             | Loading skeleton                                             | Wait for the request                                       |
+| `pending` or `progress`                        | Existing under-analysis message; do not mount metric queries | Poll status every 5 seconds while the page is active       |
+| Status request fails                           | Error with retry; not a 404 or empty data                    | Refetch status                                             |
+| `error`, `canceled`, or an unknown task status | Error with retry; do not mount metric queries                | Recheck status; this does not submit another analysis task |
+| `unsubmit` or an unresolved label              | Existing report-not-found page                               | Choose another report                                      |
+| `success`, dashboard request loading           | Loading skeleton                                             | Wait for the dashboard response                            |
+| `success`, dashboard request fails             | Error with retry; no fabricated zeroes                       | Refetch the dashboard                                      |
+| `success`, no dashboard values                 | No data available                                            | Choose another report or date range                        |
+| `success`, partial dashboard data              | Keep missing values as placeholders                          | Display the available fields                               |
+| `success`, numeric zero                        | Display `0`, including `0% (0)`                              | No recovery needed                                         |
+
+Status query results are read directly from the active query observers. All comparison reports must be accounted for before rendering results; a failed or missing report is not silently removed. Previous query data is disabled for status, dashboard, and date-verification queries so changing reports or ranges cannot reuse a previous query's result. Late responses remain attached to their original query keys. Polling stops on success, terminal task states, and request errors.
+
+The shared status gate protects the report view and the insight detail route. Detail date-verification failures also have a retry action. Individual detail charts and tables retain their existing data-query behavior; the metric-value and metric-request changes in this patch apply to the insight overview dashboard.
+
+## Backend contract and remaining gap in #285
+
+Checked against compass-web-service commit `457abf91c43548875b309d9001b3ad2ca71c6ce8`:
+
+- [AnalysisStatusVerifyQuery](https://github.com/oss-compass/compass-web-service/blob/457abf91c43548875b309d9001b3ad2ca71c6ce8/app/graphql/types/queries/analysis_status_verify_query.rb) returns `success` as soon as an Activity, Community, Codequality, or GroupActivity metric exists. It only checks the scheduler task when no such metric exists.
+- [AnalysisStatusQuery](https://github.com/oss-compass/compass-web-service/blob/457abf91c43548875b309d9001b3ad2ca71c6ce8/app/graphql/types/queries/analysis_status_query.rb) has the same shortcut, so switching to this query would not solve the gap.
+- [VerifyDetailDataRangeQuery](https://github.com/oss-compass/compass-web-service/blob/457abf91c43548875b309d9001b3ad2ca71c6ce8/app/graphql/types/queries/verify_detail_data_range_query.rb) returns a date/permission validation boolean, not a task state. `false` must not be interpreted as “analysis in progress.”
+- [ProjectTask](https://github.com/oss-compass/compass-web-service/blob/457abf91c43548875b309d9001b3ad2ca71c6ce8/app/models/project_task.rb) defines `pending`, `progress`, `success`, `error`, `canceled`, and `unsubmit` (some GraphQL descriptions misspell the last value).
+
+Consequently, this frontend change does **not** prove deep-insight readiness after project-level `success`, and does not fully resolve [#285](https://github.com/oss-compass/compass-web/issues/285). The backend needs an explicit insight-stage status tied to the current report/task before the frontend can distinguish “basic metrics ready, enrichment still running” from “completed with genuine zeroes.” It must also identify task failure and completion independently of whether metric documents already exist. No new endpoint or field is assumed in this change.
+
+## Regression coverage
+
+`MetricDashboard.test.tsx` uses real React Query observers and generated GraphQL hooks with a mocked transport. It covers loading, pending/progress polling, terminal and unknown task states, request failures and retries, comparison completeness, empty/partial data, valid zeroes, report changes, and late date-range responses. `MetricDetail/index.test.tsx` verifies the route gate and failed date-verification retries without interpreting the permission boolean as task progress.


### PR DESCRIPTION
When a project is pending or a status request fails, the insight detail route can still mount data queries or mistake failure for a missing report. The overview dashboard also turns missing numeric fields into zeroes and has no explicit request-error state.

This change shares a status gate between the report, insight route and dashboard. Pending/progress tasks show the existing analysis message and poll every 5 seconds; request and task failures show a retry action. Comparisons retain failed/missing reports instead of silently dropping them. The dashboard distinguishes loading, request failure, empty/partial data and valid numeric zeroes, including `0% (0)`. Detail date-verification failures are retryable. Current query results and query keys prevent previous reports/ranges or late responses from appearing as new data.

Related to #285. **This does not fully resolve #285:** the backend returns project-level success when basic metrics exist, without proving independent deep-insight readiness. The date-range `status` is a permission/date-validation boolean, not a task state. [The contract note](https://github.com/Yuky-499/compass-web/blob/a25ca691c18c1247425edb881ca987f79c8da107/docs/insight-analysis-states.md) links the verified backend implementation and identifies the needed insight-stage status. No progress is inferred from zeroes. Individual detail chart/table data queries retain their existing behavior.

The null-safe completion-rate checks overlap #410. This PR additionally preserves missing counts/averages as placeholders and includes status integration tests; the shared dashboard test file should be reconciled when coordinating the two PRs.

Validation:
- Full web Jest: **26 suites / 132 tests passed**, including 30 new status and detail-entry cases using real generated query hooks with a mocked transport.
- The three zero/missing-value regressions fail against the original dashboard and pass with this implementation.
- Changed-file TypeScript 4.9.5: 0 diagnostics. ESLint, Prettier, `git diff --check`, and normal pre-commit checks passed.
- System Chrome via Playwright, actual dashboard/status components with fixture APIs: loading, pending/progress, three failure/retry paths, empty/zero/partial data, polling to success, and late report responses passed (29 queries; no runtime exceptions). Checked 1440×1000 and 390×844; mobile status text is readable. The existing narrow-screen metric grid still clips values/labels; layout is unchanged.
- Full Next.js build was attempted but is blocked in this sparse checkout by missing `@public/data/collections—menus.json`. This is not a successful full build or production-backend E2E validation.
