### PR TITLE
fix: make badge actions accessible by keyboard

### DIFF
--- a/apps/web/src/modules/analyze/components/Badge.test.tsx
+++ b/apps/web/src/modules/analyze/components/Badge.test.tsx
@@ -1,0 +1,273 @@
+import React from 'react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
+import { createInstance } from 'i18next';
+import { I18nextProvider } from 'react-i18next';
+import Badge from './Badge';
+import NavbarSetting from './NavBar/NavbarSetting';
+import enAnalyze from '../../../../i18n/en/analyze.json';
+import enCommon from '../../../../i18n/en/common.json';
+import zhAnalyze from '../../../../i18n/zh/analyze.json';
+import zhCommon from '../../../../i18n/zh/common.json';
+
+jest.mock('next-i18next', () => jest.requireActual('react-i18next'));
+jest.mock('next/router', () => ({
+  useRouter: () => ({ query: { slugs: 'project-a' } }),
+}));
+jest.mock(
+  './NavBar/ChartDisplaySetting',
+  () =>
+    function ChartDisplaySetting() {
+      return <span>Chart options</span>;
+    }
+);
+jest.mock('./NavBar/RepoFilter', () => () => null);
+jest.mock('@modules/analyze/hooks/useLevel', () => () => 'repo');
+jest.mock('@modules/analyze/hooks/useCompareItems', () => () => ({
+  compareItems: [{ label: 'project-a' }],
+}));
+
+const resources = {
+  en: { analyze: enAnalyze, common: enCommon },
+  zh: { analyze: zhAnalyze, common: zhCommon },
+};
+const writeText = jest.fn();
+const originalClipboard = Object.getOwnPropertyDescriptor(
+  navigator,
+  'clipboard'
+);
+async function mount(locale: 'en' | 'zh', element = <Badge />) {
+  const i18n = createInstance();
+  await i18n.init({
+    lng: locale,
+    fallbackLng: false,
+    defaultNS: 'common',
+    resources,
+    interpolation: { escapeValue: false },
+  });
+  return render(<I18nextProvider i18n={i18n}>{element}</I18nextProvider>);
+}
+async function open(title: string) {
+  const trigger = screen.getByRole('button', { name: title });
+  act(() => trigger.focus());
+  fireEvent.click(trigger);
+  const dialog = await screen.findByRole('dialog', { name: title });
+  return { trigger, dialog };
+}
+beforeEach(() => {
+  writeText.mockReset().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, 'clipboard', {
+    configurable: true,
+    value: { writeText },
+  });
+  window.history.replaceState(null, '', '/analyze/project-a');
+});
+afterEach(() => {
+  if (originalClipboard)
+    Object.defineProperty(navigator, 'clipboard', originalClipboard);
+  else Reflect.deleteProperty(navigator, 'clipboard');
+});
+
+describe.each(['en', 'zh'] as const)(
+  '%s badge accessibility with the pinned translations',
+  (locale) => {
+    const { analyze, common } = resources[locale];
+    const title = analyze.badge.title;
+    const modelNames = [
+      common.oss_compass,
+      analyze.all_model.collaboration_development_index,
+      analyze.all_model.community_service_and_support,
+      analyze.all_model.community_activity,
+      analyze.all_model.organization_activity,
+    ];
+
+    it('names the dialog, all five model radios, close and copy controls', async () => {
+      await mount(locale);
+      const { trigger, dialog } = await open(title);
+      expect(trigger).toHaveAttribute('type', 'button');
+      expect(trigger).toHaveAttribute('aria-haspopup', 'dialog');
+      expect(trigger).toHaveAttribute('aria-controls', dialog.id);
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+      const radios = within(dialog).getAllByRole('radio');
+      expect(radios).toHaveLength(5);
+      for (const name of modelNames)
+        expect(within(dialog).getByRole('radio', { name })).toBeInTheDocument();
+      expect(
+        within(dialog).getByRole('radiogroup', { name: title })
+      ).toBeInTheDocument();
+      expect(
+        within(dialog).getByRole('button', { name: common.btn.close })
+      ).toHaveFocus();
+      expect(
+        within(dialog).getByRole('button', { name: common.copy.click_to_copy })
+      ).toHaveAttribute('type', 'button');
+      expect(
+        within(dialog).getByRole('tabpanel', { name: 'Markdown' })
+      ).toBeInTheDocument();
+    });
+
+    it('restores focus after Escape and after the close button', async () => {
+      await mount(locale);
+      const { trigger, dialog } = await open(title);
+      fireEvent.keyDown(dialog, { key: 'Escape' });
+      await waitFor(() =>
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+      );
+      expect(trigger).toHaveFocus();
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+      await open(title);
+      fireEvent.click(screen.getByRole('button', { name: common.btn.close }));
+      await waitFor(() =>
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+      );
+      expect(trigger).toHaveFocus();
+    });
+
+    it('copies the selected model in all three formats and announces success', async () => {
+      await mount(locale);
+      await open(title);
+      const radio = screen.getByRole('radio', { name: modelNames[1] });
+      fireEvent.click(radio);
+      expect(radio).toHaveAttribute('aria-checked', 'true');
+      const badge = `${window.origin}/badge/project-a.svg?metric=collab_dev_index`;
+      const expected = {
+        Markdown: `[![OSS Compass Analyze](${badge})](${window.origin}/analyze/project-a#collaboration_development_index)`,
+        HTML: `<img src="${badge}" alt="OSS Compass Analyze" />`,
+        Link: badge,
+      };
+      for (const format of ['Markdown', 'HTML', 'Link']) {
+        const tab = screen.getByRole('tab', { name: format });
+        fireEvent.click(tab);
+        const panel = screen.getByRole('tabpanel', { name: format });
+        expect(tab).toHaveAttribute('aria-controls', panel.id);
+        fireEvent.click(
+          within(panel).getByRole('button', { name: common.copy.click_to_copy })
+        );
+        await waitFor(() =>
+          expect(writeText).toHaveBeenLastCalledWith(expected[format])
+        );
+        await waitFor(() =>
+          expect(within(panel).getByRole('status')).toHaveTextContent(
+            common.copy.copy_successfully
+          )
+        );
+      }
+      expect(writeText).toHaveBeenCalledTimes(3);
+    });
+
+    it.each(['denied', 'unavailable', 'throws'])(
+      'announces clipboard failure (%s) inside the dialog',
+      async (failure) => {
+        if (failure === 'denied')
+          writeText.mockRejectedValue(new Error('NotAllowedError'));
+        if (failure === 'unavailable')
+          Reflect.deleteProperty(navigator, 'clipboard');
+        if (failure === 'throws')
+          writeText.mockImplementation(() => {
+            throw new Error('Clipboard blocked');
+          });
+        await mount(locale);
+        const { dialog } = await open(title);
+        fireEvent.click(
+          within(dialog).getByRole('button', {
+            name: common.copy.click_to_copy,
+          })
+        );
+        await waitFor(() =>
+          expect(within(dialog).getByRole('alert')).toHaveTextContent(
+            common.error.something_went_wrong
+          )
+        );
+        expect(within(dialog).getByRole('alert')).toHaveTextContent(
+          common.error.try_again
+        );
+        expect(within(dialog).getByRole('status')).toBeEmptyDOMElement();
+        expect(dialog).toContainElement(within(dialog).getByRole('alert'));
+      }
+    );
+
+    it('clears a previous format failure and can recover by copying again', async () => {
+      writeText.mockRejectedValueOnce(new Error('Denied'));
+      await mount(locale);
+      await open(title);
+      fireEvent.click(
+        screen.getByRole('button', { name: common.copy.click_to_copy })
+      );
+      await waitFor(() =>
+        expect(screen.getByRole('alert')).toHaveTextContent(
+          common.error.something_went_wrong
+        )
+      );
+      fireEvent.click(screen.getByRole('tab', { name: 'HTML' }));
+      expect(screen.getByRole('alert')).toBeEmptyDOMElement();
+      fireEvent.click(
+        screen.getByRole('button', { name: common.copy.click_to_copy })
+      );
+      await waitFor(() =>
+        expect(screen.getByRole('status')).toHaveTextContent(
+          common.copy.copy_successfully
+        )
+      );
+      expect(screen.getByRole('alert')).toBeEmptyDOMElement();
+    });
+  }
+);
+
+it('keeps focus in the settings popover after the dialog closes, then restores the settings trigger', async () => {
+  await mount('en', <NavbarSetting />);
+  const settings = screen.getByRole('button', { name: enAnalyze.display });
+  // jsdom has no layout; Popper needs a non-empty anchor rectangle.
+  jest.spyOn(settings, 'getBoundingClientRect').mockReturnValue({
+    x: 10,
+    y: 10,
+    top: 10,
+    left: 10,
+    right: 42,
+    bottom: 42,
+    width: 32,
+    height: 32,
+    toJSON: () => ({}),
+  });
+  fireEvent.click(settings);
+  const { trigger, dialog } = await open(enAnalyze.badge.title);
+  fireEvent.keyDown(dialog, { key: 'Escape' });
+  await waitFor(() =>
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  );
+  expect(trigger).toHaveFocus();
+  expect(settings).toHaveAttribute('aria-expanded', 'true');
+  fireEvent.keyDown(trigger, { key: 'Escape' });
+  await waitFor(() =>
+    expect(
+      screen.queryByRole('button', { name: enAnalyze.badge.title })
+    ).not.toBeInTheDocument()
+  );
+  expect(settings).toHaveFocus();
+  expect(settings).toHaveAttribute('aria-expanded', 'false');
+});
+
+it('does not announce a late clipboard result for a different model', async () => {
+  let finish!: () => void;
+  writeText.mockReturnValueOnce(
+    new Promise<void>((resolve) => {
+      finish = resolve;
+    })
+  );
+  await mount('en');
+  await open(enAnalyze.badge.title);
+  fireEvent.click(
+    screen.getByRole('button', { name: enCommon.copy.click_to_copy })
+  );
+  fireEvent.click(
+    screen.getByRole('radio', { name: enAnalyze.all_model.community_activity })
+  );
+  await act(async () => finish());
+  expect(screen.getByRole('status')).toBeEmptyDOMElement();
+  expect(screen.getByRole('alert')).toBeEmptyDOMElement();
+});

--- a/apps/web/src/modules/analyze/components/Badge.tsx
+++ b/apps/web/src/modules/analyze/components/Badge.tsx
@@ -1,17 +1,15 @@
-import React, { useState } from 'react';
+import React, { useId, useState } from 'react';
 import cn from 'classnames';
 import { useRouter } from 'next/router';
 import { useCountDown } from 'ahooks';
 import { useTranslation } from 'next-i18next';
 import { GrClose } from 'react-icons/gr';
-import classnames from 'classnames';
 import Dialog from '@mui/material/Dialog';
 import { BiCopy } from 'react-icons/bi';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
-import { toast } from 'react-hot-toast';
 import { Transition } from '@common/components/Dialog';
-import Tooltip from '@common//components/Tooltip';
+import Tooltip from '@common/components/Tooltip';
 import * as RadioGroup from '@radix-ui/react-radio-group';
 
 const queryMap = {
@@ -53,6 +51,8 @@ const Badge = () => {
   };
 
   const [open, setOpen] = useState(false);
+  const dialogId = useId();
+  const titleId = useId();
 
   const [badgeSrc, setBadgeSrc] = useState(badgeLinks.logo);
 
@@ -61,20 +61,24 @@ const Badge = () => {
       <div className="border-b py-2 pl-3.5 font-bold text-gray-900">
         {t('analyze:function_menu')}
       </div>
-      <div
-        className={classnames(
-          'group flex cursor-pointer py-2 pl-3.5 transition'
-        )}
+      <button
+        type="button"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-controls={open ? dialogId : undefined}
+        className="focus-visible:outline-primary group flex w-full cursor-pointer py-2 pl-3.5 text-left transition focus-visible:outline focus-visible:outline-2"
         onClick={() => {
           setOpen(true);
         }}
       >
         {t('analyze:badge.title')}
-      </div>
+      </button>
 
       <Dialog
         TransitionComponent={Transition}
         open={open}
+        aria-labelledby={titleId}
+        PaperProps={{ id: dialogId }}
         classes={{
           paper: cn(
             'border-2 border-black w-[640px] !rounded-none',
@@ -86,23 +90,33 @@ const Badge = () => {
         }}
       >
         <div className="relative px-10 py-8">
-          <p className="mb-8 text-3xl font-bold">{t('analyze:badge.title')}</p>
-          <div
-            className="absolute right-10 top-8 cursor-pointer p-2"
+          <h2 id={titleId} className="mb-8 text-3xl font-bold">
+            {t('analyze:badge.title')}
+          </h2>
+          <button
+            type="button"
+            autoFocus
+            aria-label={t('common:btn.close')}
+            className="focus-visible:outline-primary absolute right-10 top-8 cursor-pointer p-2 focus-visible:outline focus-visible:outline-2"
             onClick={() => {
               setOpen(false);
             }}
           >
-            <GrClose className="text-base" />
-          </div>
+            <GrClose className="text-base" aria-hidden="true" />
+          </button>
           <RadioGroup.Root
+            aria-labelledby={titleId}
             value={badgeSrc}
             onValueChange={(v) => {
               setBadgeSrc(v);
             }}
           >
             <div className="mb-6 grid grid-cols-2 gap-4">
-              <BadgeItem activeSrc={badgeSrc} src={badgeLinks.logo} />
+              <BadgeItem
+                activeSrc={badgeSrc}
+                src={badgeLinks.logo}
+                label={t('common:oss_compass')}
+              />
             </div>
 
             <div className="mb-2 font-medium">
@@ -112,15 +126,24 @@ const Badge = () => {
               <BadgeItem
                 activeSrc={badgeSrc}
                 src={badgeLinks.collab_dev_index}
+                label={t('analyze:all_model.collaboration_development_index')}
               />
-              <BadgeItem activeSrc={badgeSrc} src={badgeLinks.community} />
+              <BadgeItem
+                activeSrc={badgeSrc}
+                src={badgeLinks.community}
+                label={t('analyze:all_model.community_service_and_support')}
+              />
             </div>
 
             <div className="mb-2 font-medium">
               {t('analyze:topic.robustness')}
             </div>
             <div className="mb-6 grid grid-cols-2 gap-4">
-              <BadgeItem activeSrc={badgeSrc} src={badgeLinks.activity} />
+              <BadgeItem
+                activeSrc={badgeSrc}
+                src={badgeLinks.activity}
+                label={t('analyze:all_model.community_activity')}
+              />
             </div>
 
             <div className="mb-2 font-medium">
@@ -130,6 +153,7 @@ const Badge = () => {
               <BadgeItem
                 activeSrc={badgeSrc}
                 src={badgeLinks.organizations_activity}
+                label={t('analyze:all_model.organization_activity')}
               />
             </div>
           </RadioGroup.Root>
@@ -140,15 +164,24 @@ const Badge = () => {
   );
 };
 
-const BadgeItem = ({ activeSrc, src }: { activeSrc: string; src: string }) => {
+const BadgeItem = ({
+  activeSrc,
+  src,
+  label,
+}: {
+  activeSrc: string;
+  src: string;
+  label: string;
+}) => {
+  const id = useId();
   const isChecked = activeSrc === src;
   return (
     <div className="flex cursor-pointer items-center ">
       <RadioGroup.Item
         value={src}
-        id={src}
+        id={id}
         className={cn(
-          'h-[20px] w-[20px]  rounded-full border-2 bg-white outline-none ',
+          'focus-visible:ring-primary h-[20px] w-[20px] shrink-0 rounded-full border-2 bg-white outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
           [isChecked ? 'border-primary' : 'border-secondary']
         )}
       >
@@ -156,8 +189,9 @@ const BadgeItem = ({ activeSrc, src }: { activeSrc: string; src: string }) => {
       </RadioGroup.Item>
       <label
         className="flex cursor-pointer pl-[15px] text-[15px] leading-none text-black"
-        htmlFor={src}
+        htmlFor={id}
       >
+        <span className="sr-only">{label}</span>
         <img src={src} alt="" />
       </label>
     </div>
@@ -176,6 +210,11 @@ const getMarkdownAnchorLink = (badgeSrc: string) => {
 const TabPanel = ({ badgeSrc }: { badgeSrc: string }) => {
   const { t } = useTranslation();
   const [tab, setTab] = React.useState('Markdown');
+  const tabsId = useId();
+  const [copyResult, setCopyResult] = useState<{
+    source: string;
+    status: 'success' | 'error';
+  }>();
   const [targetDate, setTargetDate] = useState<number>();
   const [countdown] = useCountDown({ targetDate });
   const badgeLink = window.origin + badgeSrc;
@@ -201,6 +240,19 @@ const TabPanel = ({ badgeSrc }: { badgeSrc: string }) => {
     }
   }
 
+  const copyStatus =
+    copyResult?.source === source ? copyResult.status : undefined;
+  const copySource = async () => {
+    setCopyResult(undefined);
+    try {
+      await navigator.clipboard.writeText(source);
+      setCopyResult({ source, status: 'success' });
+      setTargetDate(Date.now() + 800);
+    } catch {
+      setCopyResult({ source, status: 'error' });
+    }
+  };
+
   return (
     <>
       <Tabs
@@ -209,7 +261,13 @@ const TabPanel = ({ badgeSrc }: { badgeSrc: string }) => {
         onChange={(e, v) => {
           setTab(v);
         }}
-        aria-label="Tabs where selection follows focus"
+        aria-label={t('analyze:badge.text')}
+        sx={{
+          '& .MuiTab-root.Mui-focusVisible': {
+            outline: '2px solid currentColor',
+            outlineOffset: '-2px',
+          },
+        }}
         selectionFollowsFocus
       >
         <Tab
@@ -217,6 +275,8 @@ const TabPanel = ({ badgeSrc }: { badgeSrc: string }) => {
           classes={{ root: '!normal-case', selected: '!text-black ' }}
           label="Markdown"
           value="Markdown"
+          id={`${tabsId}-Markdown`}
+          aria-controls={`${tabsId}-panel`}
         />
         <Tab
           disableRipple
@@ -226,6 +286,8 @@ const TabPanel = ({ badgeSrc }: { badgeSrc: string }) => {
           }}
           label="HTML"
           value="HTML"
+          id={`${tabsId}-HTML`}
+          aria-controls={`${tabsId}-panel`}
         />
         <Tab
           disableRipple
@@ -235,39 +297,50 @@ const TabPanel = ({ badgeSrc }: { badgeSrc: string }) => {
           }}
           label="Link"
           value="Link"
+          id={`${tabsId}-Link`}
+          aria-controls={`${tabsId}-panel`}
         />
       </Tabs>
-      <div className="mt-4 flex  h-[60px] items-center justify-between rounded border bg-[#fafafa] px-3">
-        <div className="break-all text-xs">{source}</div>
-        <Tooltip
-          title={
-            countdown === 0
-              ? t('common:copy.click_to_copy')
-              : t('common:copy.copy_successfully')
-          }
-          arrow
-          placement="top"
-        >
-          <div
-            className="ml-4 cursor-pointer rounded border bg-white p-1.5 hover:bg-gray-200"
-            onClick={() => {
-              if (navigator.clipboard?.writeText) {
-                navigator.clipboard
-                  .writeText(source)
-                  .then((value) => {
-                    setTargetDate(Date.now() + 800);
-                  })
-                  .catch((err) => {
-                    toast.error('Failed！No copy permission');
-                  });
-              } else {
-                toast.error('Failed！ Not Supported clipboard');
-              }
-            }}
+      <div
+        role="tabpanel"
+        id={`${tabsId}-panel`}
+        aria-labelledby={`${tabsId}-${tab}`}
+      >
+        <div className="mt-4 flex min-h-[60px] items-center justify-between rounded border bg-[#fafafa] px-3 py-2">
+          <code className="min-w-0 break-all text-xs">{source}</code>
+          <Tooltip
+            title={
+              copyStatus !== 'success' || countdown === 0
+                ? t('common:copy.click_to_copy')
+                : t('common:copy.copy_successfully')
+            }
+            arrow
+            placement="top"
+            describeChild
           >
-            <BiCopy />
-          </div>
-        </Tooltip>
+            <button
+              type="button"
+              aria-label={t('common:copy.click_to_copy')}
+              className="focus-visible:outline-primary ml-4 shrink-0 cursor-pointer rounded border bg-white p-1.5 hover:bg-gray-200 focus-visible:outline focus-visible:outline-2"
+              onClick={copySource}
+            >
+              <BiCopy aria-hidden="true" />
+            </button>
+          </Tooltip>
+        </div>
+        <p role="status" className="sr-only">
+          {copyStatus === 'success' ? t('common:copy.copy_successfully') : ''}
+        </p>
+        <p role="alert" className="mt-2 text-sm text-red-700">
+          {copyStatus === 'error' ? (
+            <>
+              {t('common:error.something_went_wrong')}{' '}
+              {t('common:error.try_again')}
+            </>
+          ) : (
+            ''
+          )}
+        </p>
       </div>
     </>
   );

--- a/apps/web/src/modules/analyze/components/NavBar/NavbarSetting.tsx
+++ b/apps/web/src/modules/analyze/components/NavBar/NavbarSetting.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useId, useRef } from 'react';
 import ChartDisplaySetting from '@modules/analyze/components/NavBar/ChartDisplaySetting';
 import RepoFilter from '@modules/analyze/components/NavBar/RepoFilter';
 import { AiOutlineSetting } from 'react-icons/ai';
@@ -7,8 +7,12 @@ import { ClickAwayListener } from '@mui/base/ClickAwayListener';
 import useLevel from '@modules/analyze/hooks/useLevel';
 import useCompareItems from '@modules/analyze/hooks/useCompareItems';
 import Badge from '../Badge';
+import { useTranslation } from 'next-i18next';
 
 const NavbarSetting: React.FC = () => {
+  const { t } = useTranslation();
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const popperId = useId();
   const level = useLevel();
   const { compareItems } = useCompareItems();
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
@@ -22,18 +26,31 @@ const NavbarSetting: React.FC = () => {
   return (
     <ClickAwayListener
       onClickAway={() => {
-        if (!open) return;
+        if (!dropdownOpen) return;
         toggleDropdown(() => false);
       }}
     >
       <div>
-        <div
-          className="mx-4 flex h-8 w-8 cursor-pointer items-center justify-center rounded-full border border-[#CFCFCF]"
+        <button
+          type="button"
+          ref={triggerRef}
+          aria-label={t('analyze:display')}
+          aria-expanded={dropdownOpen}
+          aria-controls={dropdownOpen ? popperId : undefined}
+          className="focus-visible:outline-primary mx-4 flex h-8 w-8 cursor-pointer items-center justify-center rounded-full border border-[#CFCFCF] focus-visible:outline focus-visible:outline-2"
           onClick={(e) => handleClick(e)}
         >
-          <AiOutlineSetting className="text-xl" />
-        </div>
+          <AiOutlineSetting className="text-xl" aria-hidden="true" />
+        </button>
         <Popper
+          id={popperId}
+          onKeyDown={(event) => {
+            if (event.key === 'Escape') {
+              event.stopPropagation();
+              toggleDropdown(false);
+              triggerRef.current?.focus();
+            }
+          }}
           open={dropdownOpen}
           style={{
             zIndex: 1000,


### PR DESCRIPTION
Keyboard users cannot reach the settings/badge actions because the triggers, close control and copy control are clickable divs. The badge radios also have no model names, and the dialog is not linked to its visible title.

Use native buttons with visible focus indicators for the settings trigger and badge actions. Give the dialog, radios and format panels accessible names/relationships, focus the close button on opening, and retain MUI/Radix keyboard handling and focus containment. Escape returns focus from the dialog to the badge trigger; another Escape closes the settings popover and returns to its trigger.

Announce copy success and show localized failure/retry guidance inside the dialog, including unavailable, rejected and synchronously failing clipboard APIs. Feedback is tied to the copied content so a late result cannot announce success for another model/format. Existing labels from the pinned i18n submodule are reused; its revision does not need to change.

Validation:
- **25 Jest suites / 118 tests passed**, including 16 new cases using the actual pinned English and Chinese catalogs. The two name/semantics regression cases fail against the original Badge component.
- Changed-file TypeScript 4.9.5: 0 diagnostics. ESLint, Prettier and `git diff --check` passed.
- System Chrome + Playwright: English/Chinese at 1440×1000 and 390×844. Tab/Shift+Tab, Enter/Space, model and format arrow keys, all three copy formats, clipboard failure/recovery, focus trapping and both levels of Escape/focus restoration passed.
- axe WCAG 2 A/AA and 2.1 A/AA: **0 violations in all four dialog scans**; no browser runtime exceptions or console warnings/errors, and no horizontal dialog overflow. The browser harness uses the actual changed components with fixture badge images/clipboard and simplified surrounding content; this is not a manual screen-reader or full production-page audit.
- Local Git submodule cloning timed out; tests used a GitHub API snapshot of the same pinned commit (`d3ce4a314ee4ea3de1fcb4eefc0d20ab7720e9f1`), with all four used catalog files independently verified. The CI workflow already checks out submodules recursively.
- Full Next.js build was attempted but remains blocked in the sparse local checkout by missing `@public/data/collections—menus.json`.
