### PR TITLE
feat: add model report printing (PDF phase 1)

### DIFF
--- a/apps/web/src/modules/analyze/DataView/index.tsx
+++ b/apps/web/src/modules/analyze/DataView/index.tsx
@@ -6,6 +6,7 @@ import UnderAnalysis from './Status/UnderAnalysis';
 import NotFoundAnalysis from './Status/NotFoundAnalysis';
 import LoadingAnalysis from './Status/LoadingAnalysis';
 import Charts from './Charts';
+import ReportPrint from '@modules/analyze/components/ReportPrint';
 
 const DataView = () => {
   const { notFound, isLoading, status } = useStatusContext();
@@ -25,6 +26,9 @@ const DataView = () => {
   return (
     <div className="mx-auto w-full flex-1">
       <CompareBar />
+      <div className="mt-4 flex justify-end px-4">
+        <ReportPrint />
+      </div>
       <Charts />
     </div>
   );

--- a/apps/web/src/modules/analyze/components/ReportPrint/ReportDialog.test.tsx
+++ b/apps/web/src/modules/analyze/components/ReportPrint/ReportDialog.test.tsx
@@ -1,0 +1,203 @@
+import React from 'react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import { createInstance } from 'i18next';
+import { I18nextProvider } from 'react-i18next';
+import client from '@common/gqlClient';
+import ReportDialog from './ReportDialog';
+import { ReportSelection } from './snapshot';
+import { renderReport, waitForReportAssets } from './renderReport';
+import enAnalyze from '../../../../../i18n/en/analyze.json';
+import enCommon from '../../../../../i18n/en/common.json';
+import enMetrics from '../../../../../i18n/en/metrics_models.json';
+
+jest.mock('./renderReport', () => ({
+  renderReport: jest.fn(),
+  waitForReportAssets: jest.fn(),
+}));
+
+const selection: ReportSelection = {
+  projects: [
+    {
+      label: 'https://github.com/example/one',
+      level: 'repo',
+      shortCode: 'one',
+    },
+  ],
+  start: '2026-01-01T00:00:00.000Z',
+  end: '2026-03-31T23:59:59.999Z',
+  dateLabel: '2026-01-01 ~ 2026-03-31',
+  language: 'en',
+  topic: 'collaboration',
+  repoType: 'software-artifact',
+  model: 'all',
+};
+const empty = {
+  metricCodequality: [],
+  metricCommunity: [],
+  metricActivity: [],
+  metricGroupActivity: [],
+};
+const html = '<!doctype html><html><body>Frozen report</body></html>';
+let i18n: ReturnType<typeof createInstance>;
+let request: jest.SpyInstance;
+
+beforeEach(async () => {
+  i18n = createInstance();
+  await i18n.init({
+    lng: 'en',
+    fallbackLng: false,
+    defaultNS: 'common',
+    resources: {
+      en: { analyze: enAnalyze, common: enCommon, metrics_models: enMetrics },
+    },
+  });
+  request = jest
+    .spyOn(client, 'request')
+    .mockImplementation(async ({ document }: any) =>
+      document.includes('query statusVerify')
+        ? {
+            analysisStatusVerify: {
+              ...selection.projects[0],
+              status: 'success',
+            },
+          }
+        : empty
+    );
+  jest.mocked(renderReport).mockResolvedValue(html);
+  jest.mocked(waitForReportAssets).mockResolvedValue(undefined);
+});
+afterEach(() => {
+  jest.restoreAllMocks();
+  jest.clearAllMocks();
+  jest.useRealTimers();
+});
+const mount = () =>
+  render(
+    <I18nextProvider i18n={i18n}>
+      <ReportDialog selection={selection} onClose={jest.fn()} />
+    </I18nextProvider>
+  );
+const prepare = () =>
+  fireEvent.click(screen.getByRole('button', { name: 'Prepare report' }));
+const print = () => screen.getByRole('button', { name: 'Print / Save as PDF' });
+
+test('does not print before all requests, rendering and image/font readiness complete', async () => {
+  let ready!: () => void;
+  jest.mocked(waitForReportAssets).mockReturnValue(
+    new Promise((resolve) => {
+      ready = resolve;
+    })
+  );
+  mount();
+  expect(
+    screen.getByRole('dialog', { name: 'Model and metric report' })
+  ).toBeVisible();
+  expect(print()).toBeDisabled();
+  prepare();
+  expect(screen.getByRole('status')).toHaveTextContent('Preparing');
+  const frame = await screen.findByTitle('Model and metric report');
+  fireEvent.load(frame);
+  await waitFor(() => expect(waitForReportAssets).toHaveBeenCalled());
+  expect(print()).toBeDisabled();
+  await act(async () => ready());
+  expect(print()).toBeEnabled();
+  expect(frame).toHaveAttribute('srcdoc', html);
+  expect(frame).toHaveAttribute('sandbox', 'allow-same-origin allow-modals');
+  expect(request).toHaveBeenCalledTimes(2);
+});
+
+test('shows a retryable error and never enables printing for partial failures', async () => {
+  request.mockRejectedValueOnce(new Error('network'));
+  mount();
+  prepare();
+  expect(await screen.findByRole('alert')).toHaveTextContent(
+    'could not be prepared'
+  );
+  expect(print()).toBeDisabled();
+  expect(renderReport).not.toHaveBeenCalled();
+  prepare();
+  fireEvent.load(await screen.findByTitle('Model and metric report'));
+  await waitFor(() => expect(print()).toBeEnabled());
+});
+
+test('reports unfinished analysis separately from request errors', async () => {
+  request.mockResolvedValueOnce({
+    analysisStatusVerify: { ...selection.projects[0], status: 'progress' },
+  });
+  mount();
+  prepare();
+  expect(await screen.findByRole('alert')).toHaveTextContent(
+    'Analysis is not complete'
+  );
+  expect(renderReport).not.toHaveBeenCalled();
+  expect(print()).toBeDisabled();
+});
+
+test('cancels a stale render when the model changes, then uses the new model', async () => {
+  let finish!: (html: string) => void;
+  jest.mocked(renderReport).mockReturnValueOnce(
+    new Promise((resolve) => {
+      finish = resolve;
+    })
+  );
+  mount();
+  prepare();
+  await waitFor(() => expect(renderReport).toHaveBeenCalledTimes(1));
+  const signal = jest.mocked(renderReport).mock.calls[0][2]!;
+  fireEvent.change(screen.getByRole('combobox', { name: 'Models' }), {
+    target: { value: 'metricActivity' },
+  });
+  expect(signal.aborted).toBe(true);
+  await act(async () => finish('Stale report'));
+  expect(
+    screen.queryByTitle('Model and metric report')
+  ).not.toBeInTheDocument();
+  expect(print()).toBeDisabled();
+  prepare();
+  fireEvent.load(await screen.findByTitle('Model and metric report'));
+  await waitFor(() => expect(print()).toBeEnabled());
+  expect(jest.mocked(renderReport).mock.calls[1][0].selection.model).toBe(
+    'metricActivity'
+  );
+});
+
+test('aborts outstanding requests when the dialog unmounts', async () => {
+  request.mockReturnValue(new Promise(() => {}));
+  const view = mount();
+  prepare();
+  const signal = request.mock.calls[0][0].signal as AbortSignal;
+  view.unmount();
+  expect(signal.aborted).toBe(true);
+});
+
+test('times out a stalled request and allows a fresh attempt', async () => {
+  jest.useFakeTimers();
+  request.mockReturnValue(new Promise(() => {}));
+  mount();
+  prepare();
+  const signal = request.mock.calls[0][0].signal as AbortSignal;
+  act(() => jest.advanceTimersByTime(30000));
+  expect(screen.getByRole('alert')).toHaveTextContent('could not be prepared');
+  expect(signal.aborted).toBe(true);
+  expect(print()).toBeDisabled();
+  expect(screen.getByRole('button', { name: 'Prepare report' })).toBeEnabled();
+});
+
+test('does not print an image that failed to decode', async () => {
+  jest
+    .mocked(waitForReportAssets)
+    .mockRejectedValue(new Error('decode failed'));
+  mount();
+  prepare();
+  fireEvent.load(await screen.findByTitle('Model and metric report'));
+  expect(await screen.findByRole('alert')).toHaveTextContent(
+    'could not be prepared'
+  );
+  expect(print()).toBeDisabled();
+});

--- a/apps/web/src/modules/analyze/components/ReportPrint/ReportDialog.tsx
+++ b/apps/web/src/modules/analyze/components/ReportPrint/ReportDialog.tsx
@@ -1,0 +1,212 @@
+import React, { useEffect, useId, useRef, useState } from 'react';
+import { useTranslation } from 'next-i18next';
+import Dialog from '@mui/material/Dialog';
+import { reportModels } from './catalog';
+import { reportMessages } from './messages';
+import {
+  AnalysisNotReadyError,
+  loadReportSnapshot,
+  ReportSelection,
+} from './snapshot';
+
+const TIMEOUT_MS = 30000;
+const buttonClass =
+  'rounded border px-3 py-2 text-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 disabled:opacity-50';
+
+type Preview =
+  | { state: 'idle' | 'loading' | 'error'; message?: string }
+  | { state: 'ready'; html: string };
+
+export default function ReportDialog({
+  selection,
+  onClose,
+}: {
+  selection: ReportSelection;
+  onClose: () => void;
+}) {
+  const { t, i18n } = useTranslation();
+  const titleId = useId();
+  const language = selection.language;
+  const [model, setModel] = useState('all');
+  const [preview, setPreview] = useState<Preview>({ state: 'idle' });
+  const [printReady, setPrintReady] = useState(false);
+  const frame = useRef<HTMLIFrameElement>(null);
+  const job = useRef<AbortController | null>(null);
+  const timer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const messages = reportMessages(i18n, language);
+  const reportT = i18n.getFixedT(language);
+
+  const cancel = () => {
+    job.current?.abort();
+    job.current = null;
+    clearTimeout(timer.current);
+  };
+  useEffect(() => cancel, []);
+
+  const prepare = async () => {
+    cancel();
+    const controller = new AbortController();
+    job.current = controller;
+    setPrintReady(false);
+    setPreview({ state: 'loading' });
+    timer.current = setTimeout(() => {
+      controller.abort();
+      if (job.current === controller) {
+        job.current = null;
+        setPreview({ state: 'error', message: messages.failed });
+      }
+    }, TIMEOUT_MS);
+    try {
+      const [snapshot, renderer] = await Promise.all([
+        loadReportSnapshot(
+          { ...selection, language, model },
+          controller.signal
+        ),
+        import('./renderReport'),
+      ]);
+      if (job.current !== controller || controller.signal.aborted) return;
+      const html = await renderer.renderReport(
+        snapshot,
+        i18n,
+        controller.signal
+      );
+      if (job.current !== controller || controller.signal.aborted) return;
+      setPreview({ state: 'ready', html });
+      // The deadline also covers font/image decoding in the iframe.
+    } catch (error) {
+      if (job.current !== controller || controller.signal.aborted) return;
+      cancel();
+      setPreview({
+        state: 'error',
+        message:
+          error instanceof AnalysisNotReadyError
+            ? messages.notReady
+            : messages.failed,
+      });
+    }
+  };
+  const reset = () => {
+    cancel();
+    setPrintReady(false);
+    setPreview({ state: 'idle' });
+  };
+
+  return (
+    <Dialog
+      open
+      onClose={onClose}
+      aria-labelledby={titleId}
+      maxWidth="lg"
+      fullWidth
+    >
+      <div className="flex flex-col gap-4 p-5">
+        <div className="flex items-center justify-between gap-4">
+          <h2 id={titleId} className="text-xl font-semibold">
+            {messages.title}
+          </h2>
+          <button type="button" className={buttonClass} onClick={onClose}>
+            {t('common:btn.close')}
+          </button>
+        </div>
+        <p className="text-sm text-gray-600">{messages.scope}</p>
+        <p className="break-all text-sm">
+          {selection.projects.map((project) => project.label).join(' / ')}
+          <br />
+          {selection.dateLabel}
+        </p>
+        <div className="flex flex-wrap items-end gap-3">
+          <label className="flex min-w-0 flex-col gap-1 text-sm">
+            {messages.models}
+            <select
+              autoFocus
+              className="max-w-full rounded border p-2"
+              value={model}
+              onChange={(event) => {
+                reset();
+                setModel(event.target.value);
+              }}
+            >
+              <option value="all">{messages.all}</option>
+              {reportModels
+                .filter((item) => item.topic === selection.topic)
+                .map((item) => (
+                  <option key={item.key} value={item.key}>
+                    {reportT(item.title)}
+                  </option>
+                ))}
+            </select>
+          </label>
+          <p className="text-sm">
+            {messages.language}: {language === 'zh' ? '中文' : 'English'}
+          </p>
+          <button
+            type="button"
+            className={buttonClass}
+            disabled={preview.state === 'loading'}
+            onClick={prepare}
+          >
+            {messages.generate}
+          </button>
+          <button
+            type="button"
+            className={buttonClass}
+            disabled={!printReady}
+            onClick={() => {
+              try {
+                frame.current?.contentWindow?.focus();
+                frame.current?.contentWindow?.print();
+              } catch {
+                cancel();
+                setPrintReady(false);
+                setPreview({ state: 'error', message: messages.failed });
+              }
+            }}
+          >
+            {messages.print}
+          </button>
+        </div>
+        {(preview.state === 'loading' ||
+          (preview.state === 'ready' && !printReady)) && (
+          <p role="status">{messages.preparing}</p>
+        )}
+        {preview.state === 'error' && <p role="alert">{preview.message}</p>}
+        {preview.state === 'ready' && (
+          <iframe
+            ref={frame}
+            title={messages.title}
+            sandbox="allow-same-origin allow-modals"
+            srcDoc={preview.html}
+            className="h-[60vh] w-full border"
+            onLoad={async () => {
+              const controller = job.current;
+              const document = frame.current?.contentDocument;
+              if (!controller || !document) return;
+              document.addEventListener(
+                'keydown',
+                (event) => {
+                  if (event.key === 'Escape') {
+                    event.preventDefault();
+                    onClose();
+                  }
+                },
+                { signal: controller.signal }
+              );
+              try {
+                const { waitForReportAssets } = await import('./renderReport');
+                await waitForReportAssets(document);
+                if (job.current === controller && !controller.signal.aborted) {
+                  clearTimeout(timer.current);
+                  setPrintReady(true);
+                }
+              } catch {
+                if (job.current !== controller) return;
+                cancel();
+                setPreview({ state: 'error', message: messages.failed });
+              }
+            }}
+          />
+        )}
+      </div>
+    </Dialog>
+  );
+}

--- a/apps/web/src/modules/analyze/components/ReportPrint/catalog.ts
+++ b/apps/web/src/modules/analyze/components/ReportPrint/catalog.ts
@@ -1,0 +1,434 @@
+// Metric names reuse the analyze charts' translation keys.
+export interface ReportMetric {
+  field: string;
+  title: string;
+  qualifier?: string;
+  unit?: 'score' | 'days' | 'ratio';
+  factor?: number;
+}
+
+export interface ReportModel {
+  key: string;
+  topic: 'collaboration' | 'contributor';
+  title: string;
+  metrics: ReportMetric[];
+}
+
+export const reportModels: ReportModel[] = [
+  {
+    key: 'metricCodequality',
+    topic: 'collaboration',
+    title: 'metrics_models:collaboration_development_index.title',
+    metrics: [
+      {
+        field: 'codeQualityGuarantee',
+        title: 'metrics_models:collaboration_development_index.title',
+        unit: 'score',
+      },
+      {
+        field: 'codeMergeRatio',
+        title:
+          'metrics_models:collaboration_development_index.metrics.code_merge_ratio',
+        qualifier: 'analyze:code_merge_ratio',
+        unit: 'ratio',
+      },
+      {
+        field: 'prCount',
+        title:
+          'metrics_models:collaboration_development_index.metrics.code_merge_ratio',
+        qualifier: 'analyze:total_pr',
+      },
+      {
+        field: 'codeMergedCount',
+        title:
+          'metrics_models:collaboration_development_index.metrics.code_merge_ratio',
+        qualifier: 'analyze:code_merge',
+      },
+      {
+        field: 'codeReviewRatio',
+        title:
+          'metrics_models:collaboration_development_index.metrics.code_review_ratio',
+        qualifier: 'analyze:code_review_ratio',
+        unit: 'ratio',
+      },
+      {
+        field: 'codeReviewedCount',
+        title:
+          'metrics_models:collaboration_development_index.metrics.code_review_ratio',
+        qualifier: 'analyze:code_review',
+      },
+      {
+        field: 'commitFrequency',
+        title:
+          'metrics_models:collaboration_development_index.metrics.commit_frequency',
+        qualifier:
+          'metrics_models:collaboration_development_index.metrics.commit_frequency',
+      },
+      {
+        field: 'gitPrLinkedRatio',
+        title:
+          'metrics_models:collaboration_development_index.metrics.commit_pr_linked_ratio',
+        qualifier: 'analyze:commit_pr_linked_ratio',
+        unit: 'ratio',
+      },
+      {
+        field: 'prCommitCount',
+        title:
+          'metrics_models:collaboration_development_index.metrics.commit_pr_linked_ratio',
+        qualifier: 'analyze:commit_pr',
+      },
+      {
+        field: 'prCommitLinkedCount',
+        title:
+          'metrics_models:collaboration_development_index.metrics.commit_pr_linked_ratio',
+        qualifier: 'analyze:commit_pr_linked',
+      },
+      {
+        field: 'contributorCount',
+        title:
+          'metrics_models:collaboration_development_index.metrics.contributor_count',
+        qualifier: 'analyze:total',
+      },
+      {
+        field: 'activeC1PrCommentsContributorCount',
+        title:
+          'metrics_models:collaboration_development_index.metrics.contributor_count',
+        qualifier: 'analyze:code_reviewer',
+      },
+      {
+        field: 'activeC1PrCreateContributorCount',
+        title:
+          'metrics_models:collaboration_development_index.metrics.contributor_count',
+        qualifier: 'analyze:pr_creator',
+      },
+      {
+        field: 'activeC2ContributorCount',
+        title:
+          'metrics_models:collaboration_development_index.metrics.contributor_count',
+        qualifier: 'analyze:commit_author',
+      },
+      {
+        field: 'isMaintained',
+        title:
+          'metrics_models:collaboration_development_index.metrics.is_maintained',
+      },
+      {
+        field: 'linesAddedFrequency',
+        title:
+          'metrics_models:collaboration_development_index.metrics.lines_of_code_frequency',
+        qualifier: 'analyze:lines_add',
+      },
+      {
+        field: 'linesRemovedFrequency',
+        title:
+          'metrics_models:collaboration_development_index.metrics.lines_of_code_frequency',
+        qualifier: 'analyze:lines_remove',
+      },
+      {
+        field: 'prIssueLinkedRatio',
+        title:
+          'metrics_models:collaboration_development_index.metrics.pr_issue_linked_ratio',
+        qualifier: 'analyze:linked_issue_ratio',
+        unit: 'ratio',
+      },
+      {
+        field: 'prIssueLinkedCount',
+        title:
+          'metrics_models:collaboration_development_index.metrics.pr_issue_linked_ratio',
+        qualifier: 'analyze:linked_issue',
+      },
+    ],
+  },
+  {
+    key: 'metricCommunity',
+    topic: 'collaboration',
+    title: 'metrics_models:community_service_and_support.title',
+    metrics: [
+      {
+        field: 'communitySupportScore',
+        title: 'metrics_models:community_service_and_support.title',
+        qualifier: 'metrics_models:community_service_and_support.title',
+        unit: 'score',
+      },
+      {
+        field: 'bugIssueOpenTimeAvg',
+        title:
+          'metrics_models:community_service_and_support.metrics.bug_issue_open_time',
+        qualifier: 'analyze:average',
+        unit: 'days',
+      },
+      {
+        field: 'bugIssueOpenTimeMid',
+        title:
+          'metrics_models:community_service_and_support.metrics.bug_issue_open_time',
+        qualifier: 'analyze:median',
+        unit: 'days',
+      },
+      {
+        field: 'closedPrsCount',
+        title:
+          'metrics_models:community_service_and_support.metrics.close_pr_count',
+        qualifier:
+          'metrics_models:community_service_and_support.metrics.close_pr_count',
+      },
+      {
+        field: 'codeReviewCount',
+        title:
+          'metrics_models:community_service_and_support.metrics.code_review_count',
+        qualifier:
+          'metrics_models:community_service_and_support.metrics.code_review_count',
+      },
+      {
+        field: 'commentFrequency',
+        title:
+          'metrics_models:community_service_and_support.metrics.comment_frequency',
+        qualifier:
+          'metrics_models:community_service_and_support.metrics.comment_frequency',
+      },
+      {
+        field: 'issueFirstReponseAvg',
+        title:
+          'metrics_models:community_service_and_support.metrics.issue_first_response',
+        qualifier: 'analyze:average',
+        unit: 'days',
+      },
+      {
+        field: 'issueFirstReponseMid',
+        title:
+          'metrics_models:community_service_and_support.metrics.issue_first_response',
+        qualifier: 'analyze:median',
+        unit: 'days',
+      },
+      {
+        field: 'prOpenTimeAvg',
+        title:
+          'metrics_models:community_service_and_support.metrics.pr_open_time',
+        qualifier: 'analyze:average',
+        unit: 'days',
+      },
+      {
+        field: 'prOpenTimeMid',
+        title:
+          'metrics_models:community_service_and_support.metrics.pr_open_time',
+        qualifier: 'analyze:median',
+        unit: 'days',
+      },
+      {
+        field: 'updatedIssuesCount',
+        title:
+          'metrics_models:community_service_and_support.metrics.updated_issues_count',
+      },
+    ],
+  },
+  {
+    key: 'metricActivity',
+    topic: 'collaboration',
+    title: 'metrics_models:community_activity.title',
+    metrics: [
+      {
+        field: 'activityScore',
+        title: 'metrics_models:community_activity.title',
+        qualifier: 'metrics_models:community_activity.title',
+        unit: 'score',
+      },
+      {
+        field: 'codeReviewCount',
+        title: 'metrics_models:community_activity.metrics.code_review_count',
+        qualifier:
+          'metrics_models:community_activity.metrics.code_review_count',
+      },
+      {
+        field: 'commentFrequency',
+        title: 'metrics_models:community_activity.metrics.comment_frequency',
+        qualifier:
+          'metrics_models:community_activity.metrics.comment_frequency',
+      },
+      {
+        field: 'commitFrequency',
+        title: 'metrics_models:community_activity.metrics.commit_frequency',
+        qualifier: 'metrics_models:community_activity.metrics.commit_frequency',
+      },
+      {
+        field: 'contributorCount',
+        title: 'metrics_models:community_activity.metrics.contributor_count',
+        qualifier:
+          'metrics_models:community_activity.metrics.contributor_count',
+      },
+      {
+        field: 'orgCount',
+        title: 'metrics_models:community_activity.metrics.organization_count',
+        qualifier:
+          'metrics_models:community_activity.metrics.organization_count',
+      },
+      {
+        field: 'recentReleasesCount',
+        title:
+          'metrics_models:community_activity.metrics.recent_releases_count',
+        qualifier:
+          'metrics_models:community_activity.metrics.recent_releases_count',
+      },
+      {
+        field: 'updatedIssuesCount',
+        title: 'metrics_models:community_activity.metrics.updated_issues_count',
+        qualifier:
+          'metrics_models:community_activity.metrics.updated_issues_count',
+      },
+      {
+        field: 'updatedSince',
+        title: 'metrics_models:community_activity.metrics.updated_since',
+        qualifier: 'metrics_models:community_activity.metrics.updated_since',
+        unit: 'days',
+        factor: 30,
+      },
+    ],
+  },
+  {
+    key: 'metricGroupActivity',
+    topic: 'collaboration',
+    title: 'metrics_models:organization_activity.title',
+    metrics: [
+      {
+        field: 'organizationsActivity',
+        title: 'metrics_models:organization_activity.title',
+        qualifier: 'metrics_models:organizations_activity.title',
+        unit: 'score',
+      },
+      {
+        field: 'commitFrequency',
+        title: 'metrics_models:organization_activity.metrics.commit_frequency',
+        qualifier:
+          'metrics_models:organization_activity.metrics.commit_frequency',
+      },
+      {
+        field: 'contributionLast',
+        title: 'metrics_models:organization_activity.metrics.contribution_last',
+      },
+      {
+        field: 'contributorCount',
+        title: 'metrics_models:organization_activity.metrics.contributor_count',
+        qualifier:
+          'metrics_models:organization_activity.metrics.contributor_count',
+      },
+      {
+        field: 'orgCount',
+        title: 'metrics_models:organization_activity.metrics.org_count',
+      },
+    ],
+  },
+  {
+    key: 'metricMilestonePersona',
+    topic: 'contributor',
+    title: 'metrics_models:contributor_milestone_persona.title',
+    metrics: [
+      {
+        field: 'milestonePersonaScore',
+        title: 'metrics_models:contributor_milestone_persona.title',
+        unit: 'score',
+      },
+      {
+        field: 'activityCasualContributionPerPerson',
+        title:
+          'metrics_models:contributor_milestone_persona.metrics.activity_casual_contribution_per_person',
+      },
+      {
+        field: 'activityCasualContributorCount',
+        title:
+          'metrics_models:contributor_milestone_persona.metrics.activity_casual_contributor_count',
+      },
+      {
+        field: 'activityCoreContributionPerPerson',
+        title:
+          'metrics_models:contributor_milestone_persona.metrics.activity_core_contribution_per_person',
+      },
+      {
+        field: 'activityCoreContributorCount',
+        title:
+          'metrics_models:contributor_milestone_persona.metrics.activity_core_contributor_count',
+      },
+      {
+        field: 'activityRegularContributionPerPerson',
+        title:
+          'metrics_models:contributor_milestone_persona.metrics.activity_regular_contribution_per_person',
+      },
+      {
+        field: 'activityRegularContributorCount',
+        title:
+          'metrics_models:contributor_milestone_persona.metrics.activity_regular_contributor_count',
+      },
+    ],
+  },
+  {
+    key: 'metricRolePersona',
+    topic: 'contributor',
+    title: 'metrics_models:contributor_role_persona.title',
+    metrics: [
+      {
+        field: 'rolePersonaScore',
+        title: 'metrics_models:contributor_role_persona.title',
+        unit: 'score',
+      },
+      {
+        field: 'activityIndividualContributionPerPerson',
+        title:
+          'metrics_models:contributor_role_persona.metrics.activity_individual_contribution_per_person',
+      },
+      {
+        field: 'activityIndividualContributorCount',
+        title:
+          'metrics_models:contributor_role_persona.metrics.activity_individual_contributor_count',
+      },
+      {
+        field: 'activityOrganizationContributionPerPerson',
+        title:
+          'metrics_models:contributor_role_persona.metrics.activity_organization_contribution_per_person',
+      },
+      {
+        field: 'activityOrganizationContributorCount',
+        title:
+          'metrics_models:contributor_role_persona.metrics.activity_organization_contributor_count',
+      },
+    ],
+  },
+  {
+    key: 'metricDomainPersona',
+    topic: 'contributor',
+    title: 'metrics_models:contributor_domain_persona.title',
+    metrics: [
+      {
+        field: 'domainPersonaScore',
+        title: 'metrics_models:contributor_domain_persona.title',
+        unit: 'score',
+      },
+      {
+        field: 'activityCodeContributionPerPerson',
+        title:
+          'metrics_models:contributor_domain_persona.metrics.activity_code_contribution_per_person',
+      },
+      {
+        field: 'activityCodeContributorCount',
+        title:
+          'metrics_models:contributor_domain_persona.metrics.activity_code_contributor_count',
+      },
+      {
+        field: 'activityIssueContributionPerPerson',
+        title:
+          'metrics_models:contributor_domain_persona.metrics.activity_issue_contribution_per_person',
+      },
+      {
+        field: 'activityIssueContributorCount',
+        title:
+          'metrics_models:contributor_domain_persona.metrics.activity_issue_contributor_count',
+      },
+      {
+        field: 'activityObservationContributionPerPerson',
+        title:
+          'metrics_models:contributor_domain_persona.metrics.activity_observation_contribution_per_person',
+      },
+      {
+        field: 'activityObservationContributorCount',
+        title:
+          'metrics_models:contributor_domain_persona.metrics.activity_observation_contributor_count',
+      },
+    ],
+  },
+];

--- a/apps/web/src/modules/analyze/components/ReportPrint/index.test.tsx
+++ b/apps/web/src/modules/analyze/components/ReportPrint/index.test.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import ReportPrint from './index';
+import useCompareItems from '@modules/analyze/hooks/useCompareItems';
+import useExtractShortIds from '@modules/analyze/hooks/useExtractShortIds';
+import useQueryDateRange from '@modules/analyze/hooks/useQueryDateRange';
+import useQueryMetricType from '@modules/analyze/hooks/useQueryMetricType';
+import useVerifyDetailRangeQuery from '@modules/analyze/hooks/useVerifyDetailRangeQuery';
+import { useStatusContext } from '@modules/analyze/context';
+
+jest.mock(
+  'next/dynamic',
+  () => () =>
+    function Preview({ selection }) {
+      return (
+        <pre aria-label="Captured report">{JSON.stringify(selection)}</pre>
+      );
+    }
+);
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({
+    i18n: {
+      language: 'en',
+      getFixedT: () => (_key, options) => options.defaultValue,
+    },
+  }),
+}));
+jest.mock('@modules/analyze/hooks/useCompareItems');
+jest.mock('@modules/analyze/hooks/useExtractShortIds');
+jest.mock('@modules/analyze/hooks/useQueryDateRange');
+jest.mock('@modules/analyze/hooks/useQueryMetricType');
+jest.mock('@modules/analyze/hooks/useVerifyDetailRangeQuery');
+jest.mock('@modules/analyze/context');
+jest.mock('@modules/analyze/store', () => ({
+  chartUserSettingState: { repoType: 'governance' },
+}));
+
+const project = { label: 'project', shortCode: 'one', level: 'community' };
+const dates = {
+  timeStart: new Date('2026-01-01T00:00:00Z'),
+  timeEnd: new Date('2026-06-30T00:00:00Z'),
+};
+const button = () =>
+  screen.getByRole('button', { name: 'Print report / Save as PDF' });
+beforeEach(() => {
+  jest
+    .mocked(useCompareItems)
+    .mockReturnValue({ compareItems: [project] } as any);
+  jest.mocked(useExtractShortIds).mockReturnValue({ shortIds: ['one'] } as any);
+  jest.mocked(useQueryDateRange).mockReturnValue(dates as any);
+  jest.mocked(useQueryMetricType).mockReturnValue('collaboration');
+  jest
+    .mocked(useVerifyDetailRangeQuery)
+    .mockReturnValue({ isLoading: false } as any);
+  jest
+    .mocked(useStatusContext)
+    .mockReturnValue({ status: 'success', isLoading: false } as any);
+});
+
+test('captures current effective parameters once, independent of later page changes', () => {
+  const view = render(<ReportPrint />);
+  fireEvent.click(button());
+  const captured = JSON.parse(
+    screen.getByLabelText('Captured report').textContent!
+  );
+  expect(captured).toMatchObject({
+    projects: [project],
+    start: dates.timeStart.toISOString(),
+    end: dates.timeEnd.toISOString(),
+    repoType: 'governance',
+    language: 'en',
+    topic: 'collaboration',
+  });
+  jest
+    .mocked(useQueryDateRange)
+    .mockReturnValue({ ...dates, timeStart: new Date('2026-05-01') } as any);
+  jest.mocked(useCompareItems).mockReturnValue({
+    compareItems: [{ ...project, label: 'changed' }],
+  } as any);
+  view.rerender(<ReportPrint />);
+  expect(
+    JSON.parse(screen.getByLabelText('Captured report').textContent!)
+  ).toEqual(captured);
+});
+
+test.each([
+  { timeStart: new Date('invalid'), timeEnd: dates.timeEnd },
+  { timeStart: dates.timeStart, timeEnd: new Date('invalid') },
+  { timeStart: dates.timeEnd, timeEnd: dates.timeStart },
+])(
+  'prevents an invalid or reversed date range from throwing on export',
+  (range) => {
+    jest.mocked(useQueryDateRange).mockReturnValue(range as any);
+    render(<ReportPrint />);
+    expect(button()).toBeDisabled();
+  }
+);
+
+test('waits for contributor date-range verification to avoid capturing its temporary default', () => {
+  jest.mocked(useQueryMetricType).mockReturnValue('contributor');
+  jest
+    .mocked(useVerifyDetailRangeQuery)
+    .mockReturnValue({ isLoading: true } as any);
+  const view = render(<ReportPrint />);
+  expect(button()).toBeDisabled();
+  jest
+    .mocked(useVerifyDetailRangeQuery)
+    .mockReturnValue({ isLoading: false } as any);
+  view.rerender(<ReportPrint />);
+  expect(button()).toBeEnabled();
+});
+
+test('does not export a comparison whose failed participants have been filtered out', () => {
+  jest
+    .mocked(useExtractShortIds)
+    .mockReturnValue({ shortIds: ['one', 'failed'] } as any);
+  render(<ReportPrint />);
+  expect(button()).toBeDisabled();
+});
+
+test('blocks incomplete report status', () => {
+  jest
+    .mocked(useStatusContext)
+    .mockReturnValue({ status: 'progress', isLoading: false } as any);
+  render(<ReportPrint />);
+  expect(button()).toBeDisabled();
+});

--- a/apps/web/src/modules/analyze/components/ReportPrint/index.tsx
+++ b/apps/web/src/modules/analyze/components/ReportPrint/index.tsx
@@ -1,0 +1,75 @@
+import React, { useState } from 'react';
+import dynamic from 'next/dynamic';
+import { format } from 'date-fns';
+import { useTranslation } from 'next-i18next';
+import { FiPrinter } from 'react-icons/fi';
+import useCompareItems from '@modules/analyze/hooks/useCompareItems';
+import useQueryDateRange from '@modules/analyze/hooks/useQueryDateRange';
+import useQueryMetricType from '@modules/analyze/hooks/useQueryMetricType';
+import useExtractShortIds from '@modules/analyze/hooks/useExtractShortIds';
+import useVerifyDetailRangeQuery from '@modules/analyze/hooks/useVerifyDetailRangeQuery';
+import { useStatusContext } from '@modules/analyze/context';
+import { chartUserSettingState } from '@modules/analyze/store';
+import { reportMessages } from './messages';
+import type { ReportSelection } from './snapshot';
+
+const ReportDialog = dynamic(() => import('./ReportDialog'), { ssr: false });
+
+export default function ReportPrint() {
+  const { i18n } = useTranslation();
+  const { compareItems } = useCompareItems();
+  const { shortIds } = useExtractShortIds();
+  const { status, isLoading } = useStatusContext();
+  const { timeStart, timeEnd } = useQueryDateRange();
+  const topic = useQueryMetricType();
+  const { isLoading: rangeLoading } = useVerifyDetailRangeQuery();
+  const [selection, setSelection] = useState<ReportSelection | null>(null);
+  const language = i18n.language === 'zh' ? 'zh' : 'en';
+  const messages = reportMessages(i18n, language);
+  return (
+    <>
+      <button
+        type="button"
+        className="flex items-center gap-2 rounded border bg-white px-3 py-2 text-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 disabled:opacity-50"
+        disabled={
+          isLoading ||
+          (topic === 'contributor' && rangeLoading) ||
+          !Number.isFinite(timeStart?.getTime()) ||
+          !Number.isFinite(timeEnd?.getTime()) ||
+          timeStart > timeEnd ||
+          status !== 'success' ||
+          !compareItems.length ||
+          shortIds.length !== compareItems.length
+        }
+        onClick={() =>
+          setSelection({
+            projects: compareItems.map(({ label, level, shortCode }) => ({
+              label,
+              level,
+              shortCode,
+            })),
+            start: timeStart.toISOString(),
+            end: timeEnd.toISOString(),
+            dateLabel: `${format(timeStart, 'yyyy-MM-dd')} ~ ${format(
+              timeEnd,
+              'yyyy-MM-dd'
+            )}`,
+            language,
+            topic: topic === 'contributor' ? 'contributor' : 'collaboration',
+            repoType: chartUserSettingState.repoType,
+            model: 'all',
+          })
+        }
+      >
+        <FiPrinter aria-hidden="true" />
+        {messages.open}
+      </button>
+      {selection && (
+        <ReportDialog
+          selection={selection}
+          onClose={() => setSelection(null)}
+        />
+      )}
+    </>
+  );
+}

--- a/apps/web/src/modules/analyze/components/ReportPrint/messages.ts
+++ b/apps/web/src/modules/analyze/components/ReportPrint/messages.ts
@@ -1,0 +1,71 @@
+import type { i18n } from 'i18next';
+
+// Keep this phase usable with the pinned i18n submodule. Published catalog
+// entries override these defaults without changing the report implementation.
+const en = {
+  title: 'Model and metric report',
+  open: 'Print report / Save as PDF',
+  print: 'Print / Save as PDF',
+  generate: 'Prepare report',
+  scope:
+    'Includes model scores and metric trends for the selected projects and dates. Choose Save as PDF in the browser print dialog.',
+  models: 'Models',
+  all: 'All models',
+  language: 'Report language',
+  dates: 'Date range',
+  projects: 'Projects',
+  captured: 'Snapshot prepared at',
+  repositoryType: 'Community repository type',
+  preparing: 'Preparing the report…',
+  failed: 'The report could not be prepared. Please try again.',
+  notReady:
+    'Analysis is not complete for every selected project. Please try again later.',
+  empty: 'No data in this date range',
+  missing: 'No data',
+  latest: 'Last available value',
+  observed: 'Date / interval start',
+  value: 'Value',
+  days: 'Days',
+  score: 'Score (0-1)',
+  ratio: 'Ratio (0-1)',
+  note: 'Scores and ratios use the original 0-1 scale. Missing observations are gaps, not zero. Each table shows the last available observation and its date. Dates label observations or aggregation intervals; the first interval may start before the selected range. This report contains metric trends; it excludes the 3D distribution, insight totals and individual records.',
+};
+const zh: typeof en = {
+  title: '模型与指标报告',
+  open: '打印报告 / 保存为 PDF',
+  print: '打印 / 保存为 PDF',
+  generate: '准备报告',
+  scope:
+    '包含所选项目和时间范围的模型得分及指标趋势。请在浏览器打印窗口中选择“保存为 PDF”。',
+  models: '模型',
+  all: '全部模型',
+  language: '报告语言',
+  dates: '时间范围',
+  projects: '项目',
+  captured: '快照准备时间',
+  repositoryType: '社区仓库类型',
+  preparing: '正在准备报告…',
+  failed: '报告准备失败，请重试。',
+  notReady: '部分所选项目尚未完成分析，请稍后重试。',
+  empty: '此时间范围内没有数据',
+  missing: '无数据',
+  latest: '最近有效值',
+  observed: '日期 / 区间起点',
+  value: '数值',
+  days: '天',
+  score: '得分（0-1）',
+  ratio: '比例（0-1）',
+  note: '得分和比例使用原始的 0-1 刻度。缺失观测显示为间断，不计为零。表格列出最近的有效观测值及其日期。日期为观测或聚合区间标签，首个区间的起点可能早于所选日期。本报告包含指标趋势，不含三维分布、洞察汇总和逐条明细。',
+};
+
+export const reportMessages = (i18n: i18n, language: string) => {
+  const defaults = language === 'zh' ? zh : en;
+  const t = i18n.getFixedT(language);
+  return Object.fromEntries(
+    Object.entries(defaults).map(([key, defaultValue]) => [
+      key,
+      t(`analyze:report_pdf.${key}`, { defaultValue }),
+    ])
+  ) as typeof en;
+};
+export type ReportMessages = typeof en;

--- a/apps/web/src/modules/analyze/components/ReportPrint/renderReport.test.ts
+++ b/apps/web/src/modules/analyze/components/ReportPrint/renderReport.test.ts
@@ -1,0 +1,177 @@
+import { createInstance } from 'i18next';
+import { init } from 'echarts/core';
+import { reportModels } from './catalog';
+import { renderReport } from './renderReport';
+import { ReportSnapshot } from './snapshot';
+import enAnalyze from '../../../../../i18n/en/analyze.json';
+import zhAnalyze from '../../../../../i18n/zh/analyze.json';
+import enMetrics from '../../../../../i18n/en/metrics_models.json';
+import zhMetrics from '../../../../../i18n/zh/metrics_models.json';
+
+jest.mock('echarts/core', () => ({ init: jest.fn(), use: jest.fn() }));
+jest.mock('echarts/charts', () => ({ LineChart: {} }));
+jest.mock('echarts/components', () => ({ GridComponent: {} }));
+jest.mock('echarts/renderers', () => ({ SVGRenderer: {} }));
+
+const snapshot: ReportSnapshot = {
+  selection: {
+    projects: [
+      {
+        label: 'https://example.org/项目',
+        level: 'community',
+        shortCode: 'one',
+      },
+    ],
+    start: '2026-01-01T00:00:00.000Z',
+    end: '2026-03-31T23:59:59.999Z',
+    dateLabel: '2026-01-01 ~ 2026-03-31',
+    language: 'en',
+    topic: 'collaboration',
+    repoType: 'governance',
+    model: 'metricActivity',
+  },
+  preparedAt: '2026-04-01T10:00:00.000Z',
+  results: [
+    {
+      metricActivity: [
+        {
+          grimoireCreationDate: '2026-01-01',
+          activityScore: 0,
+          commitFrequency: 0.00000001,
+        },
+        { grimoireCreationDate: '2026-02-01', activityScore: null },
+      ],
+    },
+  ] as ReportSnapshot['results'],
+};
+let i18n: ReturnType<typeof createInstance>;
+let chart: {
+  setOption: jest.Mock;
+  renderToSVGString: jest.Mock;
+  dispose: jest.Mock;
+};
+beforeEach(async () => {
+  i18n = createInstance();
+  await i18n.init({
+    lng: 'en',
+    fallbackLng: false,
+    resources: {
+      en: { analyze: enAnalyze, metrics_models: enMetrics },
+      zh: { analyze: zhAnalyze, metrics_models: zhMetrics },
+    },
+  });
+  chart = {
+    setOption: jest.fn(),
+    renderToSVGString: jest.fn(
+      () => '<svg xmlns="http://www.w3.org/2000/svg"></svg>'
+    ),
+    dispose: jest.fn(),
+  };
+  jest.mocked(init).mockReturnValue(chart as any);
+});
+afterEach(() => jest.clearAllMocks());
+
+test.each(['en', 'zh'] as const)(
+  'renders a standalone %s snapshot with dates, metadata, zero, gaps and explicit scope',
+  async (language) => {
+    const view = await renderReport(
+      { ...snapshot, selection: { ...snapshot.selection, language } },
+      i18n
+    );
+    const doc = new DOMParser().parseFromString(view, 'text/html');
+    expect(doc.documentElement.lang).toBe(language);
+    expect(doc.body.textContent).toContain(snapshot.selection.dateLabel);
+    expect(doc.body.textContent).toContain(snapshot.preparedAt);
+    expect(doc.body.textContent).toContain(
+      language === 'en' ? 'Governance Repository' : '治理仓'
+    );
+    expect(doc.querySelector('tbody')!.textContent).toContain('0');
+    expect(doc.querySelector('tbody')!.textContent).toContain('2026-01-01');
+    expect(doc.querySelector('tbody')!.textContent).not.toContain('2026-02-01');
+    expect(doc.body.textContent).toContain('0.00000001');
+    expect(doc.body.textContent).toContain(
+      language === 'en' ? 'No data in this date range' : '此时间范围内没有数据'
+    );
+    expect(doc.body.textContent).toContain(
+      language === 'en' ? 'excludes the 3D' : '不含三维'
+    );
+    expect(doc.querySelectorAll('figure')).toHaveLength(
+      reportModels.find((model) => model.key === 'metricActivity')!.metrics
+        .length
+    );
+    expect(doc.querySelector('nav, button, canvas, script, link')).toBeNull();
+    expect(doc.querySelector('img')!.getAttribute('src')).toMatch(
+      /^data:image\/svg\+xml/
+    );
+    expect(chart.setOption).toHaveBeenCalledWith(
+      expect.objectContaining({
+        animation: false,
+        series: [
+          expect.objectContaining({ data: [0, null], connectNulls: false }),
+        ],
+      })
+    );
+    expect(chart.dispose).toHaveBeenCalledTimes(2);
+  }
+);
+
+test('includes each selected model and metric even if all data is empty', async () => {
+  const copy: ReportSnapshot = {
+    ...snapshot,
+    selection: { ...snapshot.selection, model: 'all' },
+    results: [
+      {
+        metricActivity: [],
+        metricCommunity: [],
+        metricCodequality: [],
+        metricGroupActivity: [],
+      },
+    ],
+  };
+  const doc = new DOMParser().parseFromString(
+    await renderReport(copy, i18n),
+    'text/html'
+  );
+  expect(doc.querySelectorAll('section')).toHaveLength(4);
+  expect(doc.querySelectorAll('figure')).toHaveLength(44);
+  expect(doc.querySelectorAll('img')).toHaveLength(0);
+  expect(init).not.toHaveBeenCalled();
+});
+
+test('escapes project labels and metadata instead of inserting active HTML', async () => {
+  const label = '<img src=x onerror="alert(1)"> & "project"';
+  const copy: ReportSnapshot = {
+    ...snapshot,
+    selection: {
+      ...snapshot.selection,
+      projects: [{ ...snapshot.selection.projects[0], label }],
+      dateLabel: '</title><script>alert(1)</script>',
+    },
+  };
+  const doc = new DOMParser().parseFromString(
+    await renderReport(copy, i18n),
+    'text/html'
+  );
+  expect(doc.body.textContent).toContain(label);
+  expect(doc.querySelector('script, [onerror]')).toBeNull();
+  expect(
+    doc.querySelector('meta[http-equiv="Content-Security-Policy"]')
+  ).not.toBeNull();
+});
+
+test('stops before rendering another chart when the job is cancelled', async () => {
+  const controller = new AbortController();
+  controller.abort();
+  await expect(
+    renderReport(snapshot, i18n, controller.signal)
+  ).rejects.toMatchObject({ name: 'AbortError' });
+  expect(init).not.toHaveBeenCalled();
+});
+
+test('disposes a chart if SVG rendering fails', async () => {
+  chart.renderToSVGString.mockImplementationOnce(() => {
+    throw new Error('render failed');
+  });
+  await expect(renderReport(snapshot, i18n)).rejects.toThrow('render failed');
+  expect(chart.dispose).toHaveBeenCalledTimes(1);
+});

--- a/apps/web/src/modules/analyze/components/ReportPrint/renderReport.ts
+++ b/apps/web/src/modules/analyze/components/ReportPrint/renderReport.ts
@@ -1,0 +1,209 @@
+import { init, use } from 'echarts/core';
+import { LineChart } from 'echarts/charts';
+import { GridComponent } from 'echarts/components';
+import { SVGRenderer } from 'echarts/renderers';
+import type { i18n } from 'i18next';
+import { reportModels } from './catalog';
+import { metricSeries, ReportSnapshot } from './snapshot';
+import { reportMessages } from './messages';
+
+use([LineChart, GridComponent, SVGRenderer]);
+
+const colors = ['#254bd5', '#9c3a10', '#137650', '#7d36ac'];
+export const escapeHtml = (value: string) =>
+  value.replace(
+    /[&<>"']/g,
+    (character) =>
+      ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[
+        character
+      ])
+  );
+
+const styles = `
+@page {
+  size: A4 portrait; margin: 14mm;
+  @bottom-right { content: counter(page) " / " counter(pages); color: #64748b; font: 9px Arial, sans-serif; }
+}
+* { box-sizing: border-box; }
+html { color-scheme: light; background: #fff; }
+body { margin: 0 auto; padding: 24px; max-width: 920px; color: #17202c;
+  font: 14px/1.5 Arial, "PingFang SC", "Microsoft YaHei", sans-serif; }
+h1 { font-size: 28px; line-height: 1.25; margin: 0 0 24px; }
+h2 { font-size: 21px; margin: 0 0 20px; break-after: avoid; }
+h3 { font-size: 16px; line-height: 1.4; margin: 0; }
+p { margin: 8px 0; }
+ul { padding-left: 22px; }
+li, td, dd { overflow-wrap: anywhere; }
+.cover { break-after: page; padding-bottom: 32px; }
+.brand { font-weight: bold; letter-spacing: .08em; color: #254bd5; }
+dl { margin: 24px 0; }
+dt { font-weight: bold; margin-top: 12px; }
+dd { margin: 4px 0; }
+.note, .unit { color: #4b5563; font-size: 12px; }
+.model { break-before: page; }
+figure { margin: 0 0 20px; padding: 12px 0; border-top: 1px solid #cbd5e1;
+  break-inside: avoid; page-break-inside: avoid; }
+img { display: block; width: 100%; height: auto; }
+table { width: 100%; border-collapse: collapse; table-layout: fixed; font-size: 11px; }
+th { text-align: left; color: #4b5563; font-weight: normal; }
+th:first-child { width: 60%; }
+td, th { padding: 4px 6px; vertical-align: top; border-bottom: 1px solid #e5e7eb; }
+.empty { padding: 40px 16px; text-align: center; border: 1px dashed #cbd5e1; }
+@media print {
+  body { max-width: none; padding: 0; font-size: 12px; }
+  * { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+}
+`;
+
+// Render from the captured data, independently of the page's viewport,
+// animations, live query cache and per-card interaction state.
+export async function renderReport(
+  snapshot: ReportSnapshot,
+  i18n: i18n,
+  signal?: AbortSignal
+): Promise<string> {
+  const { selection } = snapshot;
+  const t = i18n.getFixedT(selection.language);
+  const messages = reportMessages(i18n, selection.language);
+  const number = new Intl.NumberFormat(selection.language, {
+    maximumSignificantDigits: 6,
+  });
+  const models = reportModels.filter(
+    (model) =>
+      model.topic === selection.topic &&
+      (selection.model === 'all' || selection.model === model.key)
+  );
+  const sections: string[] = [];
+  for (const model of models) {
+    const figures: string[] = [];
+    for (const metric of model.metrics) {
+      // Yield between charts so closing, changing a model and the deadline can
+      // cancel long reports without waiting for every SVG to finish.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
+      const qualifier = metric.qualifier ? t(metric.qualifier) : '';
+      const title =
+        t(metric.title) +
+        (qualifier && qualifier !== t(metric.title) ? ` / ${qualifier}` : '');
+      const { dates, series } = metricSeries(snapshot, model.key, metric);
+      const hasData = series.some((item) =>
+        item.values.some((value) => value !== null)
+      );
+      let visual = `<p class="empty">${escapeHtml(messages.empty)}</p>`;
+      if (hasData) {
+        const chart = init(null, undefined, {
+          renderer: 'svg',
+          ssr: true,
+          width: 900,
+          height: 245,
+        });
+        try {
+          chart.setOption({
+            animation: false,
+            color: colors,
+            grid: {
+              left: 12,
+              right: 25,
+              top: 20,
+              bottom: 16,
+              containLabel: true,
+            },
+            xAxis: {
+              type: 'category',
+              data: dates.map((date) => date.slice(0, 10)),
+              axisLabel: { hideOverlap: true, fontSize: 16 },
+            },
+            yAxis: {
+              type: 'value',
+              splitNumber: 3,
+              axisLabel: { fontSize: 16 },
+            },
+            series: series.map((item) => ({
+              type: 'line',
+              name: item.label,
+              data: item.values,
+              connectNulls: false,
+              showSymbol: true,
+              symbolSize: 4,
+            })),
+          });
+          visual = `<img alt="${escapeHtml(
+            title
+          )}" src="data:image/svg+xml;charset=utf-8,${encodeURIComponent(
+            chart.renderToSVGString()
+          )}">`;
+        } finally {
+          chart.dispose();
+        }
+      }
+      const rows = series
+        .map((item, index) => {
+          let latest = item.values.length - 1;
+          while (latest >= 0 && item.values[latest] === null) latest--;
+          return `<tr><td><span style="color:${
+            colors[index % colors.length]
+          }">●</span> ${escapeHtml(item.label)}</td><td>${
+            latest < 0
+              ? escapeHtml(messages.missing)
+              : escapeHtml(number.format(item.values[latest]!))
+          }</td><td>${
+            latest < 0 ? '/' : escapeHtml(dates[latest].slice(0, 10))
+          }</td></tr>`;
+        })
+        .join('');
+      const unit = metric.unit ? messages[metric.unit] : messages.value;
+      figures.push(
+        `<figure><h3>${escapeHtml(title)}</h3><p class="unit">${escapeHtml(
+          unit
+        )}</p>${visual}<table><thead><tr><th>${escapeHtml(
+          messages.projects
+        )}</th><th>${escapeHtml(messages.latest)}</th><th>${escapeHtml(
+          messages.observed
+        )}</th></tr></thead><tbody>${rows}</tbody></table></figure>`
+      );
+    }
+    sections.push(
+      `<section class="model"><h2>${escapeHtml(
+        t(model.title)
+      )}</h2>${figures.join('')}</section>`
+    );
+  }
+  const repoType =
+    selection.repoType === 'governance'
+      ? t('analyze:repos_type.governance_repository')
+      : t('analyze:repos_type.software_artifact_repository');
+  return `<!doctype html><html lang="${
+    selection.language
+  }"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src data:; style-src 'unsafe-inline'"><title>OSS Compass - ${escapeHtml(
+    messages.title
+  )} - ${escapeHtml(
+    selection.dateLabel
+  )}</title><style>${styles}</style></head><body><header class="cover"><p class="brand">OSS COMPASS</p><h1>${escapeHtml(
+    messages.title
+  )}</h1><dl><dt>${escapeHtml(messages.dates)}</dt><dd>${escapeHtml(
+    selection.dateLabel
+  )}</dd><dt>${escapeHtml(messages.projects)}</dt><dd><ul>${selection.projects
+    .map(({ label }) => `<li>${escapeHtml(label)}</li>`)
+    .join('')}</ul></dd><dt>${escapeHtml(messages.language)}</dt><dd>${
+    selection.language === 'zh' ? '中文' : 'English'
+  }</dd>${
+    selection.projects.some((project) => project.level === 'community')
+      ? `<dt>${escapeHtml(messages.repositoryType)}</dt><dd>${escapeHtml(
+          repoType
+        )}</dd>`
+      : ''
+  }<dt>${escapeHtml(messages.captured)}</dt><dd>${escapeHtml(
+    snapshot.preparedAt
+  )}</dd><dt>${escapeHtml(messages.models)}</dt><dd><ul>${models
+    .map((model) => `<li>${escapeHtml(t(model.title))}</li>`)
+    .join('')}</ul></dd></dl><p class="note">${escapeHtml(
+    messages.note
+  )}</p></header><main>${sections.join('')}</main></body></html>`;
+}
+
+export async function waitForReportAssets(document: Document) {
+  await Promise.all([
+    document.fonts?.ready,
+    ...Array.from(document.images).map((image) => image.decode()),
+  ]);
+}

--- a/apps/web/src/modules/analyze/components/ReportPrint/snapshot.test.ts
+++ b/apps/web/src/modules/analyze/components/ReportPrint/snapshot.test.ts
@@ -1,0 +1,266 @@
+import { parse, OperationDefinitionNode, FieldNode } from 'graphql';
+import { createInstance } from 'i18next';
+import client from '@common/gqlClient';
+import {
+  MetricDocument,
+  MetricContributorDocument,
+  StatusVerifyDocument,
+} from '@oss-compass/graphql';
+import {
+  AnalysisNotReadyError,
+  loadReportSnapshot,
+  metricSeries,
+  ReportSelection,
+  ReportSnapshot,
+} from './snapshot';
+import { reportModels } from './catalog';
+import enAnalyze from '../../../../../i18n/en/analyze.json';
+import zhAnalyze from '../../../../../i18n/zh/analyze.json';
+import enMetrics from '../../../../../i18n/en/metrics_models.json';
+import zhMetrics from '../../../../../i18n/zh/metrics_models.json';
+
+const selection: ReportSelection = {
+  projects: [
+    {
+      label: 'https://github.com/example/one',
+      level: 'repo',
+      shortCode: 'one',
+    },
+  ],
+  start: '2026-01-01T00:00:00.000Z',
+  end: '2026-03-31T23:59:59.999Z',
+  dateLabel: '2026-01-01 ~ 2026-03-31',
+  language: 'en',
+  topic: 'collaboration',
+  repoType: 'software-artifact',
+  model: 'metricActivity',
+};
+const success = {
+  analysisStatusVerify: { ...selection.projects[0], status: 'success' },
+};
+
+beforeEach(() => jest.restoreAllMocks());
+
+test('captures the effective dates, original values and selection independently of later updates', async () => {
+  const input = JSON.parse(JSON.stringify(selection));
+  const result = {
+    metricActivity: [{ grimoireCreationDate: '2026-02-01', activityScore: 0 }],
+  };
+  const request = jest
+    .spyOn(client, 'request')
+    .mockResolvedValueOnce(success)
+    .mockResolvedValueOnce(result);
+  const controller = new AbortController();
+  const pending = loadReportSnapshot(input, controller.signal);
+  input.start = '2030-01-01';
+  input.projects[0].label = 'changed';
+  const snapshot = await pending;
+  result.metricActivity[0].activityScore = 1;
+  expect(snapshot.selection).toEqual(selection);
+  expect(snapshot.results[0]).toEqual({
+    metricActivity: [{ grimoireCreationDate: '2026-02-01', activityScore: 0 }],
+  });
+  expect(request).toHaveBeenNthCalledWith(1, {
+    document: StatusVerifyDocument,
+    variables: { shortCode: 'one' },
+    signal: controller.signal,
+  });
+  expect(request).toHaveBeenNthCalledWith(2, {
+    document: MetricDocument,
+    variables: {
+      label: selection.projects[0].label,
+      level: 'repo',
+      start: selection.start,
+      end: selection.end,
+      repoType: '',
+    },
+    signal: controller.signal,
+  });
+});
+
+test('uses the contributor query and community repository filter', async () => {
+  const input: ReportSelection = {
+    ...selection,
+    topic: 'contributor',
+    model: 'all',
+    repoType: 'governance',
+    projects: [{ ...selection.projects[0], level: 'community' }],
+  };
+  const request = jest
+    .spyOn(client, 'request')
+    .mockResolvedValueOnce({
+      analysisStatusVerify: { ...input.projects[0], status: 'success' },
+    })
+    .mockResolvedValueOnce({
+      metricMilestonePersona: [],
+      metricDomainPersona: [],
+      metricRolePersona: [],
+    });
+  await loadReportSnapshot(input, new AbortController().signal);
+  expect(request).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      document: MetricContributorDocument,
+      variables: expect.objectContaining({
+        repoType: 'governance',
+        level: 'community',
+      }),
+    })
+  );
+});
+
+test.each(['pending', 'progress', 'error', 'canceled', 'unsubmit', 'unknown'])(
+  'blocks %s status without requesting metrics',
+  async (status) => {
+    const request = jest.spyOn(client, 'request').mockResolvedValueOnce({
+      analysisStatusVerify: { ...selection.projects[0], status },
+    });
+    await expect(
+      loadReportSnapshot(selection, new AbortController().signal)
+    ).rejects.toBeInstanceOf(AnalysisNotReadyError);
+    expect(request).toHaveBeenCalledTimes(1);
+  }
+);
+
+test('rejects a missing or mismatched project identity', async () => {
+  const request = jest
+    .spyOn(client, 'request')
+    .mockResolvedValueOnce({ analysisStatusVerify: null })
+    .mockResolvedValueOnce({
+      analysisStatusVerify: {
+        ...selection.projects[0],
+        label: 'wrong',
+        status: 'success',
+      },
+    });
+  await expect(
+    loadReportSnapshot(selection, new AbortController().signal)
+  ).rejects.toBeInstanceOf(AnalysisNotReadyError);
+  await expect(
+    loadReportSnapshot(selection, new AbortController().signal)
+  ).rejects.toBeInstanceOf(AnalysisNotReadyError);
+  expect(request).toHaveBeenCalledTimes(2);
+});
+
+test('does not publish a comparison when one project request fails', async () => {
+  const input = {
+    ...selection,
+    projects: [
+      ...selection.projects,
+      { label: 'two', shortCode: 'two', level: 'repo' },
+    ],
+  };
+  jest
+    .spyOn(client, 'request')
+    .mockResolvedValueOnce(success)
+    .mockResolvedValueOnce({
+      analysisStatusVerify: { ...input.projects[1], status: 'success' },
+    })
+    .mockResolvedValueOnce({ metricActivity: [] })
+    .mockRejectedValueOnce(new Error('Network error'));
+  await expect(
+    loadReportSnapshot(input, new AbortController().signal)
+  ).rejects.toThrow('Network error');
+});
+
+test.each([{}, { metricActivity: null }])(
+  'rejects incomplete model responses: %j',
+  async (result) => {
+    jest
+      .spyOn(client, 'request')
+      .mockResolvedValueOnce(success)
+      .mockResolvedValueOnce(result);
+    await expect(
+      loadReportSnapshot(selection, new AbortController().signal)
+    ).rejects.toThrow('Incomplete metric response');
+  }
+);
+
+test('keeps an empty array distinct from a failed response', async () => {
+  jest
+    .spyOn(client, 'request')
+    .mockResolvedValueOnce(success)
+    .mockResolvedValueOnce({ metricActivity: [] });
+  await expect(
+    loadReportSnapshot(selection, new AbortController().signal)
+  ).resolves.toMatchObject({ results: [{ metricActivity: [] }] });
+});
+
+test('aligns comparison dates, keeps boundary buckets and zero, and filters invalid dates/types', () => {
+  const snapshot = {
+    selection: {
+      ...selection,
+      projects: [...selection.projects, { label: 'two' }],
+    },
+    results: [
+      {
+        metricActivity: [
+          { grimoireCreationDate: '2026-02-01', updatedSince: 0 },
+          { grimoireCreationDate: '2026-03-01', updatedSince: null },
+          {
+            grimoireCreationDate: '2026-01-01',
+            updatedSince: 99,
+            type: 'governance',
+          },
+          { grimoireCreationDate: '2025-12-29', updatedSince: 99 },
+          { grimoireCreationDate: 'invalid', updatedSince: 99 },
+        ],
+      },
+      {
+        metricActivity: [
+          { grimoireCreationDate: '2026-01-01', updatedSince: 2 },
+          { grimoireCreationDate: '2026-03-01', updatedSince: '' },
+        ],
+      },
+    ],
+  } as ReportSnapshot;
+  expect(
+    metricSeries(snapshot, 'metricActivity', {
+      field: 'updatedSince',
+      title: '',
+      factor: 30,
+    })
+  ).toEqual({
+    dates: ['2025-12-29', '2026-01-01', '2026-02-01', '2026-03-01'],
+    series: [
+      { label: selection.projects[0].label, values: [2970, null, 0, null] },
+      { label: 'two', values: [null, 60, null, null] },
+    ],
+  });
+});
+
+test('every report field exists in the real GraphQL query and every title is translated in both languages', async () => {
+  const i18n = createInstance();
+  await i18n.init({
+    resources: {
+      en: { analyze: enAnalyze, metrics_models: enMetrics },
+      zh: { analyze: zhAnalyze, metrics_models: zhMetrics },
+    },
+    fallbackLng: false,
+  });
+  for (const model of reportModels) {
+    const query = parse(
+      model.topic === 'collaboration'
+        ? MetricDocument
+        : MetricContributorDocument
+    ).definitions[0] as OperationDefinitionNode;
+    const root = query.selectionSet.selections.find(
+      (field: FieldNode) => field.name.value === model.key
+    ) as FieldNode;
+    const fields = root.selectionSet!.selections.map(
+      (field: FieldNode) => field.name.value
+    );
+    expect(new Set(model.metrics.map((metric) => metric.field)).size).toBe(
+      model.metrics.length
+    );
+    for (const metric of model.metrics) {
+      expect(fields).toContain(metric.field);
+      for (const lng of ['en', 'zh']) {
+        expect(i18n.exists(metric.title, { lng })).toBe(true);
+        if (metric.qualifier)
+          expect(i18n.exists(metric.qualifier, { lng })).toBe(true);
+      }
+    }
+    for (const lng of ['en', 'zh'])
+      expect(i18n.exists(model.title, { lng })).toBe(true);
+  }
+});

--- a/apps/web/src/modules/analyze/components/ReportPrint/snapshot.ts
+++ b/apps/web/src/modules/analyze/components/ReportPrint/snapshot.ts
@@ -1,0 +1,134 @@
+import client from '@common/gqlClient';
+import {
+  MetricDocument,
+  MetricContributorDocument,
+  StatusVerifyDocument,
+  MetricQuery,
+  MetricContributorQuery,
+  StatusVerifyQuery,
+} from '@oss-compass/graphql';
+import type { CommunityRepoType } from '@common/constant';
+import { ReportMetric, reportModels } from './catalog';
+
+export interface ReportSelection {
+  projects: { label: string; level: string; shortCode: string }[];
+  start: string;
+  end: string;
+  dateLabel: string;
+  language: 'en' | 'zh';
+  topic: 'collaboration' | 'contributor';
+  repoType: CommunityRepoType;
+  model: string;
+}
+export interface ReportSnapshot {
+  selection: ReportSelection;
+  preparedAt: string;
+  results: (MetricQuery | MetricContributorQuery)[];
+}
+export class AnalysisNotReadyError extends Error {}
+
+export async function loadReportSnapshot(
+  selection: ReportSelection,
+  signal: AbortSignal
+): Promise<ReportSnapshot> {
+  // Own the selection and responses: subsequent navigation and query-cache
+  // refreshes cannot change a preview that has already been prepared.
+  const frozen = JSON.parse(JSON.stringify(selection)) as ReportSelection;
+  if (!frozen.projects.length) throw new Error('No selected projects');
+  const statuses = await Promise.all(
+    frozen.projects.map(({ shortCode }) =>
+      client.request<StatusVerifyQuery>({
+        document: StatusVerifyDocument,
+        variables: { shortCode },
+        signal,
+      })
+    )
+  );
+  if (
+    statuses.some(
+      ({ analysisStatusVerify: item }, index) =>
+        !item ||
+        item.status !== 'success' ||
+        item.label !== frozen.projects[index].label ||
+        item.level !== frozen.projects[index].level
+    )
+  ) {
+    throw new AnalysisNotReadyError();
+  }
+  const results = await Promise.all(
+    frozen.projects.map(({ label, level }) =>
+      client.request<MetricQuery | MetricContributorQuery>({
+        document:
+          frozen.topic === 'collaboration'
+            ? MetricDocument
+            : MetricContributorDocument,
+        variables: {
+          label,
+          level,
+          start: frozen.start,
+          end: frozen.end,
+          repoType: level === 'community' ? frozen.repoType : '',
+        },
+        signal,
+      })
+    )
+  );
+  // A null/missing model is not an empty result array. Do not silently publish
+  // a partial report when the service violates the selected model contract.
+  const models = reportModels.filter(
+    (model) =>
+      model.topic === frozen.topic &&
+      (frozen.model === 'all' || model.key === frozen.model)
+  );
+  if (
+    !models.length ||
+    results.some((result) =>
+      models.some((model) => !Array.isArray(result?.[model.key]))
+    )
+  )
+    throw new Error('Incomplete metric response');
+  return {
+    selection: frozen,
+    preparedAt: new Date().toISOString(),
+    results: JSON.parse(JSON.stringify(results)),
+  };
+}
+
+export function metricSeries(
+  snapshot: ReportSnapshot,
+  model: string,
+  metric: ReportMetric
+) {
+  // The API applies the date bounds before aggregation. Its first bucket
+  // label can precede the requested start; filtering labels again loses data.
+  const rows = snapshot.results.map((result) =>
+    (result[model] as Record<string, unknown>[]).filter(
+      (row) =>
+        (!row.type || row.type === snapshot.selection.repoType) &&
+        typeof row.grimoireCreationDate === 'string' &&
+        Number.isFinite(Date.parse(row.grimoireCreationDate))
+    )
+  );
+  const dates = Array.from(
+    new Set(
+      rows.flatMap((items) =>
+        items.map((row) => row.grimoireCreationDate as string)
+      )
+    )
+  ).sort((a, b) => Date.parse(a) - Date.parse(b));
+  const series = rows.map((items, index) => {
+    const values = new Map(
+      items.map((row) => [row.grimoireCreationDate, row[metric.field]])
+    );
+    return {
+      label: snapshot.selection.projects[index].label,
+      values: dates.map((date) => {
+        const value = values.get(date);
+        return typeof value === 'number' && Number.isFinite(value)
+          ? value * (metric.factor ?? 1)
+          : null;
+      }),
+    };
+  });
+  return { dates, series };
+}

--- a/docs/pdf-reports.md
+++ b/docs/pdf-reports.md
@@ -1,0 +1,138 @@
+# PDF report delivery phases
+
+Related: [compass-web #73](https://github.com/oss-compass/compass-web/issues/73).
+This issue also requests email delivery and a GPG signature. The browser-print
+phase below does **not** close it.
+
+## Phase 1: printable model and metric snapshots
+
+On the analysis report, choose the projects, date range, community repository
+type and page language, then select **Print report / Save as PDF**. Select one
+model or all models in the current collaboration/contributor topic, prepare the
+preview, and use **Print / Save as PDF**. The browser supplies the PDF save dialog.
+
+The report contains the four collaboration models (44 metric series, including
+variants normally selected through chart tabs) or the three contributor models
+(19 series). It includes a cover with the captured conditions and preparation
+time, vector trend charts, and each project's last available value with its
+observation date. The fixed report layout uses original 0-1 scores/ratios and
+unconnected gaps for missing observations; time-since-last-update is converted
+from months to days using the existing 30-day convention. A genuine zero remains
+zero. An empty metric remains in the report with an explicit no-data message.
+The bug-issue-duration series uses the API's `bugIssueOpenTimeAvg/Mid` fields.
+
+This is a **model/metric trend report**, not a copy of every interactive widget.
+The preview and cover explain the scope. It excludes the 3D distribution,
+current/all-time insight totals, paginated contributor/issue/PR records and
+population reference lines. Per-card zoom, tab and display settings do not
+change its documented scales or content. PNG/SVG card sharing and CSV export
+remain separate actions.
+
+### Snapshot and failure behavior
+
+- The entry captures the effective date bounds from `useQueryDateRange`, not a
+  relative range that could be reinterpreted when printing. Contributor range
+  verification must finish before capture. The API filters before aggregation,
+  so returned bucket labels are retained even if the first bucket starts before
+  the requested start; the cover explains this interval-label convention. It also captures the
+  project identities, topic, repository filter and current language. Navigation
+  and changes behind the dialog do not rewrite that selection.
+- Preparation re-verifies **every** selected project's identity/status and
+  requests the existing `metric` or `metricContributor` query once per project.
+  It does not read filtered/stale chart-provider state or a partially populated
+  cache. Any failed request or missing model array prevents publication of the
+  entire preview. Empty arrays are successful no-data results.
+- Data and conditions are copied into a browser-owned snapshot. SVG generation
+  uses that snapshot, yields between metrics, disables animation, and disposes
+  each ECharts instance. No viewport scrolling or lazy chart loading is needed.
+- Preparation has a 30-second deadline covering requests, chart rendering and
+  image/font readiness. Changing the selected model, closing the dialog or
+  reaching the deadline aborts the job. A late result cannot replace another
+  preview. Failures allow a new preparation attempt.
+- The isolated, script-free iframe contains its own print CSS, embedded SVG
+  images and system fonts. Printing is enabled only after its images decode and
+  fonts are ready. The original analysis document is not modified. Escape also
+  closes the dialog when focus is inside the preview.
+- This is an immutable **client capture**, not a server-wide atomic database
+  snapshot. Different project queries can observe different service update
+  moments. The cover says "Snapshot prepared at", not "analysis completed at".
+  Existing status APIs only establish their current analysis readiness contract;
+  this feature does not claim to solve insight-specific readiness (#285).
+
+Metric/model names reuse the pinned i18n submodule. New report labels use
+`analyze:report_pdf.*` with colocated English/Chinese defaults, so this PR does not
+depend on an unmerged translation commit. Catalog entries with those keys take
+precedence when added upstream. No submodule URL or revision changes are needed.
+
+### Validation
+
+Automated tests cover real GraphQL documents and translation keys, frozen
+selection/data, exact request parameters, both topics, zero/null/empty data,
+comparison failures, status gating, cancellation, timeout, asset readiness,
+HTML escaping and chart disposal. Browser QA should exercise the actual dialog,
+GraphQL transport and SVG renderer with controlled responses, then print the
+same generated document in Chrome and inspect the resulting PDF pages.
+
+Manual acceptance:
+
+1. Open an English and a Chinese analysis report; select dates and prepare a
+   single model and an all-model report. Check the cover against those inputs.
+2. Print to A4/PDF. Check the last metric as well as the first, readable Chinese,
+   chart/table alignment, long project names, model page breaks and empty data.
+3. Compare projects with zeros and missing dates. A missing sample must not turn
+   into zero, and the last-value table must show its actual observation date.
+4. Simulate an API failure, incomplete analysis and stalled preparation. Printing
+   must stay unavailable until a complete retry succeeds.
+5. Change models or close during preparation. Verify cancellation and that an
+   older response never replaces the new preview. Check keyboard focus/closing,
+   including Escape from inside the iframe.
+
+The local sparse checkout may prevent a full Next.js build because public data
+and image resources are not checked out. Targeted checks or a fixture browser
+harness must not be described as a successful full application build.
+
+## Phase 2: server-generated PDF jobs and downloads (not implemented)
+
+No PDF generation job/download contract was found in the current
+`compass-web-service` GraphQL operations during implementation. The following is
+a **proposed contract for discussion**, not an endpoint called by this PR.
+Backend and frontend maintainers need to agree on it before connecting a job UI.
+
+- Create a job from validated project identities, absolute dates, model IDs,
+  repository type, language and a versioned report format. The service must
+  apply the same access/date restrictions as interactive queries. Do not trust
+  client-supplied metric values as an authoritative report.
+- Capture the selected data once and persist an immutable `snapshotId` with its
+  schema version and capture time. Generation/retries/downloads must refer to
+  that snapshot rather than re-running queries for each output.
+- Return `jobId`, `snapshotId`, and a state from `queued`, `running`, `ready`,
+  `failed`, `expired`. Status responses include timestamps and a stable error
+  code. A ready result includes a download URL, expiry, content type, file name,
+  byte length and SHA-256 digest. Polling ends at terminal states and should be
+  bounded/backed off. Repeated submissions need an idempotency key.
+- Use the service's worker infrastructure for font installation, chart/asset
+  readiness, execution limits, retry policy and cleanup. Fonts must cover both
+  languages. Test large comparisons, absent metrics, worker timeout, repeated
+  requests and expired download links.
+- Assign ownership for the schema, worker/storage lifecycle, snapshot format and
+  report rendering version. Reuse phase-1 model definitions/layout where useful;
+  the current frontend renderer alone does not provide queueing or storage.
+
+## Phase 3: email delivery and GPG signatures (not implemented)
+
+This requires backend work and deployment configuration in addition to the PDF
+job contract. The frontend should only request operations and display results.
+
+- Deliver the exact completed PDF identified by `snapshotId` and digest. Validate
+  the destination and caller's access on the service, queue delivery, and expose
+  delivery failure/retry status without regenerating different report bytes.
+- Produce a detached GPG signature over the final PDF bytes on the service.
+  Return the signature download, signing-key fingerprint and verification
+  instructions. Publish the verification public key through an agreed channel.
+  Private signing keys and email credentials never enter a browser bundle.
+- Define storage/retention, signing-key rotation, delivery retry/idempotency and
+  access to expired artifacts before exposing those controls. Verify a downloaded
+  PDF/signature pair end to end and verify that modified bytes fail validation.
+
+Only close #73 when generation/download, email delivery and signature verification
+are complete, or when maintainers explicitly reduce the issue's scope.


### PR DESCRIPTION
The analysis page has per-chart image exports but no way to print a selected-date model report. This adds **Print report / Save as PDF** and a standalone preview for one or all models in the current collaboration/contributor topic.

Related to #73. This delivers the **browser-print phase only**. Server-generated download jobs, email delivery and GPG signatures remain outstanding; `docs/pdf-reports.md` records the phase boundaries and proposed service contract.

## Behavior

- Capture the selected projects, effective date bounds, repository type and page language. Re-verify every project and fetch a complete set of metrics independently of the live chart cache. A failed participant prevents a partial comparison from being printed.
- Render 44 collaboration or 19 contributor metric series as static vector SVGs, with a conditions cover, last available values/dates, A4 page breaks and page numbers. Empty results are explicit, zeros remain zero, and missing samples remain gaps. Preserve service aggregation buckets whose labels precede the requested range.
- Keep printing unavailable until fonts/images are ready. A 30-second deadline, cancellation and stale-result guards cover requests, rendering and preview readiness. Escape works inside the preview and focus returns to the entry button.
- Use original 0-1 score/ratio scales. The preview/cover explicitly exclude the 3D distribution, insight totals, individual records and population reference lines. This is a model/metric trend report, not a full-page screenshot or a server-wide atomic snapshot.
- Reuse metric translations; colocated English/Chinese defaults for `analyze:report_pdf.*` keep the feature independent of an unmerged i18n commit. No dependency or submodule revision changes.

## Validation

- Full Jest suite: **28 suites / 137 tests passed**, including 35 new tests for capture, real query/translation contracts, status and failure handling, null/zero data, cancellation, timeout, image readiness, escaping and disposal.
- Changed-file TypeScript: **0 diagnostics**; ESLint and normal pre-commit checks passed.
- Chrome fixture integration: actual entry/dialog, GraphQL transport and ECharts SVG renderer, using controlled report context/API responses. English collaboration, Chinese four-project long-name comparison, Chinese contributor report and empty data; desktop/mobile viewports; keyboard open/close, correct print target, retry/cancellation, no runtime errors/warnings or horizontal overflow.
- Printed those exact preview documents through Chrome: **18 / 25 / 9 / 4 pages**, all rendered and visually reviewed. Four report accessibility scans: **0 axe WCAG 2 A/AA and 2.1 A/AA violations**. This is not a full production-site end-to-end run or a manual screen-reader audit.
- Full Next.js build could not complete in this sparse checkout: missing `apps/web/public/data/collections—menus.json`. Targeted checks are not presented as a successful application build.

Deduplication checked all PR states for PDF/print/report/export/GPG/打印 and the #73 timeline. No matching PDF implementation was found; merged report refactor #267 does not add PDF export. Existing service GraphQL operations/REST routes/dependencies did not expose a PDF job or signature contract.
